### PR TITLE
Upgrade Keycloak version to 23.0.3

### DIFF
--- a/folio-backend-testing/pom.xml
+++ b/folio-backend-testing/pom.xml
@@ -11,6 +11,7 @@
 
   <name>folio-backend-testing</name>
   <artifactId>folio-backend-testing</artifactId>
+  <version>1.1.0-SNAPSHOT</version>
   <description/>
 
   <properties>
@@ -18,7 +19,7 @@
     <jsonassert.version>1.5.1</jsonassert.version>
     <jjwt.version>0.9.1</jjwt.version>
     <apache-commons-lang3.version>3.12.0</apache-commons-lang3.version>
-    <testcontainers-keycloak.version>3.0.0</testcontainers-keycloak.version>
+    <testcontainers-keycloak.version>3.2.0</testcontainers-keycloak.version>
   </properties>
 
   <dependencies>

--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/KeycloakContainerExtension.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/KeycloakContainerExtension.java
@@ -18,7 +18,7 @@ import org.keycloak.representations.idm.PartialImportRepresentation;
 public class KeycloakContainerExtension implements BeforeAllCallback, AfterAllCallback {
 
   @SuppressWarnings("resource")
-  private static final KeycloakContainer CONTAINER = new KeycloakContainer("quay.io/keycloak/keycloak:22.0.1")
+  private static final KeycloakContainer CONTAINER = new KeycloakContainer("quay.io/keycloak/keycloak:23.0.3")
     .withFeaturesEnabled("scripts", "token-exchange", "admin-fine-grained-authz")
     .withProviderLibsFrom(List.of(readToFile("keycloak/folio-scripts.jar", "folio-scripts", ".jar")));
 

--- a/folio-security/pom.xml
+++ b/folio-security/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <spring-cloud-bom.version>2022.0.1</spring-cloud-bom.version>
-    <keycloak-admin-client.version>	23.0.3</keycloak-admin-client.version>
+    <keycloak-admin-client.version>23.0.3</keycloak-admin-client.version>
     <jwks-rsa.version>0.22.0</jwks-rsa.version>
   </properties>
 

--- a/folio-security/pom.xml
+++ b/folio-security/pom.xml
@@ -10,10 +10,11 @@
 
   <name>folio-security</name>
   <artifactId>folio-security</artifactId>
+  <version>1.1.0-SNAPSHOT</version>
 
   <properties>
     <spring-cloud-bom.version>2022.0.1</spring-cloud-bom.version>
-    <keycloak-admin-client.version>22.0.1</keycloak-admin-client.version>
+    <keycloak-admin-client.version>	23.0.3</keycloak-admin-client.version>
     <jwks-rsa.version>0.22.0</jwks-rsa.version>
   </properties>
 


### PR DESCRIPTION
### Purpose
Upgrade Keycloak version for testing and for folio-security to the latest: `v23.0.3`

### Approach
- Upgrade Keycloak test container to `v23.0.3`
- Raise version of libraries: `folio-testing`, `folio-security`

### TODOs and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
