### PR TITLE
APPPOCTOOL-1: upgrade spring boot version to 3.2.0

### DIFF
--- a/folio-backend-common/pom.xml
+++ b/folio-backend-common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>applications-poc-tools</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <name>folio-backend-common</name>

--- a/folio-backend-testing/pom.xml
+++ b/folio-backend-testing/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>applications-poc-tools</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <name>folio-backend-testing</name>

--- a/folio-integration-kafka/pom.xml
+++ b/folio-integration-kafka/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>applications-poc-tools</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <name>folio-integration-kafka</name>

--- a/folio-secret-store/folio-secret-store-common/pom.xml
+++ b/folio-secret-store/folio-secret-store-common/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>folio-secret-store</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <name>folio-secret-store-common</name>

--- a/folio-secret-store/folio-secret-store-common/pom.xml
+++ b/folio-secret-store/folio-secret-store-common/pom.xml
@@ -61,7 +61,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.8</version>
+        <version>0.8.11</version>
         <executions>
           <execution>
             <id>prepare-agent</id>

--- a/folio-secret-store/folio-secret-store-starter/pom.xml
+++ b/folio-secret-store/folio-secret-store-starter/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>folio-secret-store</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <name>folio-secret-store-starter</name>

--- a/folio-secret-store/pom.xml
+++ b/folio-secret-store/pom.xml
@@ -7,11 +7,12 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>applications-poc-tools</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <name>folio-secret-store</name>
   <artifactId>folio-secret-store</artifactId>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <description/>
 

--- a/folio-security/pom.xml
+++ b/folio-security/pom.xml
@@ -91,6 +91,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
+      <version>5.2.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/folio-security/pom.xml
+++ b/folio-security/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>applications-poc-tools</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <name>folio-security</name>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <name>applications-poc-tools</name>
   <groupId>org.folio</groupId>
   <artifactId>applications-poc-tools</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <description>Library with general purpose classes to help with FOLIO backend development and testing</description>
   <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.4</version>
+    <version>3.2.0</version>
     <relativePath/>
   </parent>
 
@@ -34,27 +34,22 @@
 
   <properties>
     <java.version>17</java.version>
-    <lombok.version>1.18.26</lombok.version>
-    <spring-boot.version>3.0.4</spring-boot.version>
+    <lombok.version>1.18.30</lombok.version>
+    <spring-boot.version>3.2.0</spring-boot.version>
     <apache-commons-collections4.version>4.4</apache-commons-collections4.version>
     <spring-kafka.version>3.0.4</spring-kafka.version>
     <spring-boot-starter-validation.version>3.0.4</spring-boot-starter-validation.version>
 
     <!-- Test dependencies versions -->
     <wiremock.version>2.33.2</wiremock.version>
-    <testcontainer.version>1.17.2</testcontainer.version>
+    <testcontainer.version>1.19.3</testcontainer.version>
 
     <!-- Plugins versions -->
     <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-    <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
     <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
-    <maven-surefire-plugin.version>3.0.0-M9</maven-surefire-plugin.version>
-    <maven-failsafe-plugin.version>3.0.0-M9</maven-failsafe-plugin.version>
-    <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-release-plugin.version>3.0.0-M7</maven-release-plugin.version>
-    <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
     <folio-java-checkstyle.version>1.0.0-SNAPSHOT</folio-java-checkstyle.version>
   </properties>
 


### PR DESCRIPTION
### Purpose
Since spring-boot 3.2.0 version has been released the repo should be updated as well.

### Approach
- upgrade spring-boot to 3.2.0
- fix issues 
