### PR TITLE
Use "alpine" version of postgres in test containers

### DIFF
--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/PostgresContainerExtension.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/PostgresContainerExtension.java
@@ -10,7 +10,7 @@ public class PostgresContainerExtension implements BeforeAllCallback, AfterAllCa
   private static final String SPRING_PROPERTY_NAME = "spring.datasource.url";
 
   @SuppressWarnings("resource")
-  private static final PostgreSQLContainer<?> CONTAINER = new PostgreSQLContainer<>("postgres:12.11")
+  private static final PostgreSQLContainer<?> CONTAINER = new PostgreSQLContainer<>("postgres:12-alpine")
     .withDatabaseName("folio_test")
     .withUsername("folio_admin")
     .withPassword("qwerty123");


### PR DESCRIPTION
## Purpose
Using "alpine" version of postgres in test containers to minimize image size