### PR TITLE
[MGRENTITLE-26] Fix Keycloak resources creation issues

### DIFF
--- a/folio-security/src/main/java/org/folio/security/integration/keycloak/service/KeycloakImportService.java
+++ b/folio-security/src/main/java/org/folio/security/integration/keycloak/service/KeycloakImportService.java
@@ -51,7 +51,7 @@ public class KeycloakImportService {
   public void importData() {
     var descriptor = descriptorProvider.getModuleDescriptor();
     var descriptorHash = descriptor.hashCode();
-    var mappings = mapper.map(descriptor);
+    var mappings = mapper.map(descriptor, false);
     var clientId = props.getClient().getClientId();
     var realmResource = keycloakClient.realm(REALM);
     var client = getClientIfExists(realmResource, clientId);

--- a/folio-security/src/main/java/org/folio/security/integration/keycloak/service/KeycloakModuleDescriptorMapper.java
+++ b/folio-security/src/main/java/org/folio/security/integration/keycloak/service/KeycloakModuleDescriptorMapper.java
@@ -45,7 +45,8 @@ public class KeycloakModuleDescriptorMapper {
   private static final String SCOPE_PERM_DELIMITER = "#";
 
   public KeycloakMappings map(ModuleDescriptor descriptor, boolean excludeSystemInterfaces) {
-    log.debug("Preparing keycloak mappings from module descriptor [id='{}']", descriptor.getId());
+    log.debug("Preparing keycloak mappings from module descriptor [id='{}', excludeSystemInterfaces={}]",
+      descriptor.getId(), excludeSystemInterfaces);
 
     var allScopes = mapScopes(HTTP_METHODS);
     var roleMappings = mapRoles(descriptor);

--- a/folio-security/src/main/java/org/folio/security/integration/keycloak/service/KeycloakModuleDescriptorMapper.java
+++ b/folio-security/src/main/java/org/folio/security/integration/keycloak/service/KeycloakModuleDescriptorMapper.java
@@ -3,20 +3,20 @@ package org.folio.security.integration.keycloak.service;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.collections4.ListUtils.emptyIfNull;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.common.utils.CollectionUtils.toStream;
 import static org.folio.common.utils.UuidUtils.randomId;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -44,13 +44,13 @@ public class KeycloakModuleDescriptorMapper {
   private static final String PERM_ATTRIBUTE_KEY = "folio_permissions";
   private static final String SCOPE_PERM_DELIMITER = "#";
 
-  public KeycloakMappings map(ModuleDescriptor descriptor) {
+  public KeycloakMappings map(ModuleDescriptor descriptor, boolean excludeSystemInterfaces) {
     log.debug("Preparing keycloak mappings from module descriptor [id='{}']", descriptor.getId());
 
     var allScopes = mapScopes(HTTP_METHODS);
     var roleMappings = mapRoles(descriptor);
     var rolePolicyMappings = mapPolicies(roleMappings);
-    var resourceMappings = mapResources(descriptor);
+    var resourceMappings = mapResources(descriptor, excludeSystemInterfaces);
     var resourceScopeMappings = associateScopes(allScopes, resourceMappings);
     var permissions = mapPermissions(rolePolicyMappings, resourceScopeMappings, resourceMappings);
     var resourceServer = mapResourceServer(allScopes, resourceMappings.values());
@@ -83,10 +83,11 @@ public class KeycloakModuleDescriptorMapper {
     return policies;
   }
 
-  public Map<RoutingEntry, ResourceRepresentation> mapResources(ModuleDescriptor descriptor) {
+  public Map<RoutingEntry, ResourceRepresentation> mapResources(ModuleDescriptor descriptor,
+    boolean excludeSystemInterfaces) {
     var resourceMap = new HashMap<String, ResourceRepresentation>();
     var routingEntryResourceMap = new HashMap<RoutingEntry, ResourceRepresentation>();
-    for (var handler : getRoutingEntries(descriptor)) {
+    for (var handler : getRoutingEntries(descriptor, excludeSystemInterfaces)) {
       var path = StringUtils.getIfEmpty(handler.getPath(), handler::getPathPattern);
 
       // one resource can represent multiple routing entries
@@ -95,9 +96,6 @@ public class KeycloakModuleDescriptorMapper {
 
       // combine permissions for resources
       setAttributesForResource(resource, resourceAttribute);
-      // ad-hoc to support "resource by permission" lookup in scope of US1118978
-      // (keycloak doesn't support search for resources by attribute)
-      updateResourceType(resource, resourceAttribute);
 
       routingEntryResourceMap.put(handler, resource);
     }
@@ -122,40 +120,25 @@ public class KeycloakModuleDescriptorMapper {
     return permission;
   }
 
-  private static String prepareAttributeForResources(RoutingEntry handler) {
+  private static List<String> prepareAttributeForResources(RoutingEntry handler) {
     if (Objects.isNull(handler)) {
-      return EMPTY;
+      return Collections.emptyList();
     }
     var methods = emptyIfNull(handler.getMethods());
-    var permissionsWithScopes = emptyIfNull(handler.getPermissionsRequired())
+    return emptyIfNull(handler.getPermissionsRequired())
       .stream().map(perm -> String.join(SCOPE_PERM_DELIMITER, methods) + SCOPE_PERM_DELIMITER + perm)
-      .collect(toSet());
-    return String.join(",", permissionsWithScopes);
+      .distinct()
+      .collect(Collectors.toCollection(ArrayList::new));
   }
 
-  private static void setAttributesForResource(ResourceRepresentation resource, String permissions) {
+  private static void setAttributesForResource(ResourceRepresentation resource, List<String> permissions) {
     if (MapUtils.isEmpty(resource.getAttributes())) {
       var mapAttr = new HashMap<String, List<String>>();
-      mapAttr.put(PERM_ATTRIBUTE_KEY, List.of(permissions));
+      mapAttr.put(PERM_ATTRIBUTE_KEY, permissions);
       resource.setAttributes(mapAttr);
     } else {
       var mapAttr = resource.getAttributes();
-      var attr = mapAttr.get(PERM_ATTRIBUTE_KEY);
-      var attrToSet = CollectionUtils.isEmpty(attr)
-        ? List.of(permissions)
-        : List.of(String.join(",", attr.get(0), permissions));
-      mapAttr.put(PERM_ATTRIBUTE_KEY, attrToSet);
-      resource.setAttributes(mapAttr);
-    }
-  }
-
-  private static void updateResourceType(ResourceRepresentation resource, String permissions) {
-    var type = resource.getType();
-
-    if (isEmpty(type)) {
-      resource.setType(permissions);
-    } else {
-      resource.setType(String.join(",", type, permissions));
+      mapAttr.computeIfAbsent(PERM_ATTRIBUTE_KEY, k -> new ArrayList<>()).addAll(permissions);
     }
   }
 
@@ -185,10 +168,14 @@ public class KeycloakModuleDescriptorMapper {
   private static ResourceServerRepresentation mapResourceServer(List<ScopeRepresentation> scopes,
     Collection<ResourceRepresentation> resources) {
     var authorizationSettings = new ResourceServerRepresentation();
+    authorizationSettings.setResources(getDistinctResources(resources));
     authorizationSettings.setScopes(scopes);
-    authorizationSettings.setResources(new ArrayList<>(resources));
     authorizationSettings.setDecisionStrategy(DecisionStrategy.AFFIRMATIVE);
     return authorizationSettings;
+  }
+
+  private static List<ResourceRepresentation> getDistinctResources(Collection<ResourceRepresentation> resources) {
+    return resources.stream().distinct().toList();
   }
 
   private static Map<RoutingEntry, Set<ScopeRepresentation>> associateScopes(
@@ -303,10 +290,12 @@ public class KeycloakModuleDescriptorMapper {
     return scopes.stream().filter(scope -> scope.getName().equals(name)).findFirst();
   }
 
-  private static List<RoutingEntry> getRoutingEntries(ModuleDescriptor descriptor) {
-    return toStream(descriptor.getProvides())
-      .flatMap(i -> toStream(i.getHandlers()))
-      .toList();
+  private static List<RoutingEntry> getRoutingEntries(ModuleDescriptor descriptor, boolean excludeSystemInterfaces) {
+    var stream = toStream(descriptor.getProvides());
+    if (excludeSystemInterfaces) {
+      stream = stream.filter(i -> !"system".equals(i.getInterfaceType()));
+    }
+    return stream.flatMap(i -> toStream(i.getHandlers())).toList();
   }
 
   private static List<Permission> getPermissionSets(ModuleDescriptor descriptor) {

--- a/folio-security/src/test/java/org/folio/security/integration/keycloak/service/KeycloakModuleDescriptorMapperTest.java
+++ b/folio-security/src/test/java/org/folio/security/integration/keycloak/service/KeycloakModuleDescriptorMapperTest.java
@@ -4,11 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.test.TestUtils.parse;
 import static org.folio.test.TestUtils.readString;
 
-import org.assertj.core.api.ThrowingConsumer;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.folio.common.domain.model.ModuleDescriptor;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.ScopeRepresentation;
 
 @UnitTest
 class KeycloakModuleDescriptorMapperTest {
@@ -16,34 +19,62 @@ class KeycloakModuleDescriptorMapperTest {
   private static final ModuleDescriptor MD = parse(readString("json/mappingDescriptor.json"), ModuleDescriptor.class);
   private static final ModuleDescriptor EMPTY_MD =
     parse(readString("json/emptyDescriptor.json"), ModuleDescriptor.class);
-  private static final String RESOURCE_FOO = "/foo";
-  private static final String RESOURCE_FOO_PERMS = "POST#foo.item.post";
-  private static final String RESOURCE_FOO_ID = "/foo/{id}";
-  private static final String RESOURCE_FOO_ID_PERMS = "GET#foo.item.get,PUT#foo.item.put,DELETE#foo.item.delete";
+
+  private static final String FOO_RESOURCE = "/foo";
+  private static final List<String> FOO_SCOPES = List.of("POST");
+  private static final List<String> FOO_PERMS = List.of("POST#foo.item.post");
+
+  private static final String FOO_BY_ID = "/foo/{id}";
+  private static final List<String> FOO_BY_ID_SCOPES = List.of("GET", "PUT", "DELETE");
+  private static final List<String> FOO_BY_ID_PERMS =
+    List.of("GET#foo.item.get", "PUT#foo.item.put", "DELETE#foo.item.delete");
+
+  private static final String TIMER_RESOURCE = "/foo/timer";
+  private static final List<String> TIMER_PERMISSIONS = Collections.emptyList();
+  private static final List<String> TIMER_SCOPES = List.of("POST");
 
   private final KeycloakModuleDescriptorMapper mapper = new KeycloakModuleDescriptorMapper();
 
   @Test
-  void map_positive_resourceTypeWithPermissions() {
-    var actual = mapper.map(MD);
+  void map_positive() {
+    var fooResource = resource(FOO_RESOURCE, FOO_PERMS, FOO_SCOPES);
+    var fooByIdResource = resource(FOO_BY_ID, FOO_BY_ID_PERMS, FOO_BY_ID_SCOPES);
+    var timerResource = resource(TIMER_RESOURCE, TIMER_PERMISSIONS, TIMER_SCOPES);
+
+    var actual = mapper.map(MD, false);
 
     var resources = actual.getResourceServer().getResources();
-    assertThat(resources).anySatisfy(resourceWithTypeAndName(RESOURCE_FOO_ID, RESOURCE_FOO_ID_PERMS));
-    assertThat(resources).anySatisfy(resourceWithTypeAndName(RESOURCE_FOO, RESOURCE_FOO_PERMS));
+
+    assertThat(resources).usingRecursiveFieldByFieldElementComparatorIgnoringFields("id")
+      .containsExactlyInAnyOrder(fooResource, fooByIdResource, timerResource);
+  }
+
+  @Test
+  void map_positive_excludingSystemInterfaces() {
+    var fooResource = resource(FOO_RESOURCE, FOO_PERMS, FOO_SCOPES);
+    var fooByIdResource = resource(FOO_BY_ID, FOO_BY_ID_PERMS, FOO_BY_ID_SCOPES);
+
+    var actual = mapper.map(MD, true);
+
+    var resources = actual.getResourceServer().getResources();
+
+    assertThat(resources).usingRecursiveFieldByFieldElementComparatorIgnoringFields("id")
+      .containsExactlyInAnyOrder(fooResource, fooByIdResource);
   }
 
   @Test
   void map_positive_emptyModuleDescriptor() {
-    var actual = mapper.map(EMPTY_MD);
+    var actual = mapper.map(EMPTY_MD, false);
 
     var resources = actual.getResourceServer().getResources();
     assertThat(resources).isEmpty();
   }
 
-  private static ThrowingConsumer<ResourceRepresentation> resourceWithTypeAndName(String name, String type) {
-    return res -> {
-      assertThat(res.getName()).isEqualTo(name);
-      assertThat(res.getType()).isEqualTo(type);
-    };
+  private static ResourceRepresentation resource(String name, List<String> folioPermissions, List<String> scopes) {
+    var resource = new ResourceRepresentation();
+    scopes.stream().map(ScopeRepresentation::new).forEach(resource::addScope);
+    resource.setName(name);
+    resource.setAttributes(Map.of("folio_permissions", folioPermissions));
+    return resource;
   }
 }

--- a/folio-security/src/test/resources/json/mappingDescriptor.json
+++ b/folio-security/src/test/resources/json/mappingDescriptor.json
@@ -27,6 +27,21 @@
           "permissionsRequired": [ "foo.item.delete" ]
         }
       ]
+    },
+    {
+      "id": "_timer",
+      "version": "1.0",
+      "interfaceType": "system",
+      "handlers": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/foo/timer",
+          "unit": "day",
+          "delay": "5"
+        }
+      ]
     }
   ],
   "requires": [


### PR DESCRIPTION
### Purpose
Keycloak resource creation fails if:
- folio_permissions attribute value is longer than 255 symbols
- an endpoint has additional handler in system interfaces (such as _timer)

JIRA: https://issues.folio.org/browse/MGRENTITLE-26
### Approach
- Store folio_permissions into multiple values
- Remove folio permissions from **Type** field as it's not used currently and it also has a length limit of 255 symbols
- Add support to exclude system interfaces from mapper processing
