### PR TITLE
Fix sonarcloud code smells

### DIFF
--- a/folio-integration-kong/src/main/java/org/folio/tools/kong/service/KongGatewayService.java
+++ b/folio-integration-kong/src/main/java/org/folio/tools/kong/service/KongGatewayService.java
@@ -4,7 +4,6 @@ import static java.util.Collections.emptyList;
 import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toCollection;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.codec.digest.DigestUtils.sha1Hex;
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
@@ -321,6 +320,6 @@ public class KongGatewayService {
 
   @SafeVarargs
   private static <T> List<T> getNonNullValues(T ... nullableValues) {
-    return Stream.of(nullableValues).filter(Objects::nonNull).collect(toList());
+    return Stream.of(nullableValues).filter(Objects::nonNull).toList();
   }
 }

--- a/folio-integration-kong/src/test/java/org/folio/tools/kong/service/KongGatewayServiceTest.java
+++ b/folio-integration-kong/src/test/java/org/folio/tools/kong/service/KongGatewayServiceTest.java
@@ -162,9 +162,10 @@ class KongGatewayServiceTest {
 
       var routingEntry = new RoutingEntry().methods(List.of("GET")).pathPattern("/entities/{id}");
       var interfaceDesc = new InterfaceDescriptor().id("test").version("1.0").handlers(List.of(routingEntry));
-      var moduleDesc = new ModuleDescriptor().id(MOD_ID).provides(List.of(interfaceDesc));
+      var moduleDescriptor = new ModuleDescriptor().id(MOD_ID).provides(List.of(interfaceDesc));
 
-      assertThatThrownBy(() -> kongGatewayService.addRoutes(TENANT_NAME, List.of(moduleDesc)))
+      var moduleDescriptors = List.of(moduleDescriptor);
+      assertThatThrownBy(() -> kongGatewayService.addRoutes(TENANT_NAME, moduleDescriptors))
         .isInstanceOf(KongIntegrationException.class)
         .hasMessage("Failed to create routes")
         .satisfies(error -> assertThat(((KongIntegrationException) error).getErrors()).isEqualTo(
@@ -176,10 +177,10 @@ class KongGatewayServiceTest {
     @Test
     void negative_serviceNotFound() {
       var request = create(GET, "/services/" + MOD_ID, emptyMap(), null, (RequestTemplate) null);
-      var moduleDescriptor = moduleDescriptor();
       when(kongAdminClient.getService(MOD_ID)).thenThrow(new NotFound("Not found", request, null, emptyMap()));
 
-      assertThatThrownBy(() -> kongGatewayService.addRoutes(TENANT_NAME, List.of(moduleDescriptor)))
+      var moduleDescriptors = List.of(moduleDescriptor());
+      assertThatThrownBy(() -> kongGatewayService.addRoutes(TENANT_NAME, moduleDescriptors))
         .isInstanceOf(KongIntegrationException.class)
         .hasMessage("Failed to find Kong service for module: test-module-0.0.1")
         .satisfies(error -> assertThat(((KongIntegrationException) error).getErrors()).isEqualTo(List.of(
@@ -331,9 +332,8 @@ class KongGatewayServiceTest {
       var request = create(GET, "/services/" + MOD_ID, emptyMap(), null, (RequestTemplate) null);
       when(kongAdminClient.getService(MOD_ID)).thenThrow(new NotFound("Not found", request, null, emptyMap()));
 
-      var moduleDescriptor = moduleDescriptor();
-
-      assertThatThrownBy(() -> kongGatewayService.addRoutes(TENANT_NAME, List.of(moduleDescriptor)))
+      var moduleDescriptors = List.of(moduleDescriptor());
+      assertThatThrownBy(() -> kongGatewayService.addRoutes(TENANT_NAME, moduleDescriptors))
         .isInstanceOf(KongIntegrationException.class)
         .hasMessage("Failed to find Kong service for module: test-module-0.0.1")
         .satisfies(error -> assertThat(((KongIntegrationException) error).getErrors()).isEqualTo(List.of(


### PR DESCRIPTION
### Purpose
Fixes sonarcloud code smells raised by implementing `folio-integration-kong` library

### Approach

- Replace `.collect(toList())` with `.toList()`
- Fix issues in unit tests

### TODOs and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
