### PR TITLE
MGRAPPS-2 Implement ability to remove service

### DIFF
--- a/folio-integration-kong/src/main/java/org/folio/tools/kong/service/KongGatewayService.java
+++ b/folio-integration-kong/src/main/java/org/folio/tools/kong/service/KongGatewayService.java
@@ -110,6 +110,20 @@ public class KongGatewayService {
     }
   }
 
+  /**
+   * Deletes Kong service by service name or id.
+   *
+   * @throws KongIntegrationException - if integration exception happened
+   */
+  public void deleteService(String serviceNameOrId) {
+    try {
+      kongAdminClient.deleteService(serviceNameOrId);
+    } catch (Exception e) {
+      var parameters = List.of(new Parameter().key("cause").value(e.getMessage()));
+      throw new KongIntegrationException("Failed to delete Kong service: " + serviceNameOrId, parameters);
+    }
+  }
+
   private String getUrl(Service service) {
     return service.getUrl() != null
       ? service.getUrl()
@@ -137,7 +151,7 @@ public class KongGatewayService {
 
     var routes = prepareRoutes(moduleDescriptor, moduleId, tenant);
     var newRoutesCreationErrors = toStream(routes)
-      .filter(not(pair1 -> existingRouteNames.contains(pair1.getLeft().getName())))
+      .filter(not(pair -> existingRouteNames.contains(pair.getLeft().getName())))
       .map(pair -> createKongRoute(serviceId, pair.getLeft(), pair.getRight()))
       .flatMap(Optional::stream)
       .toList();
@@ -319,7 +333,7 @@ public class KongGatewayService {
   }
 
   @SafeVarargs
-  private static <T> List<T> getNonNullValues(T ... nullableValues) {
+  private static <T> List<T> getNonNullValues(T... nullableValues) {
     return Stream.of(nullableValues).filter(Objects::nonNull).toList();
   }
 }


### PR DESCRIPTION
### Purpose
Implements an ability to remove a Kong service using `KongGatewayService`
US: [MGRAPPS-2](https://folio-org.atlassian.net/browse/MGRAPPS-2)

### Approach
- Implement a method 'deleteService` in `KongGatewayService`
- Add unit tests to verify call to `KongAdminClient`

### TODOs and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
