### PR TITLE
KEYCLOAK-6 Raise keycloak version to v23.0.6

### DIFF
--- a/folio-backend-testing/pom.xml
+++ b/folio-backend-testing/pom.xml
@@ -10,7 +10,7 @@
 
   <name>folio-backend-testing</name>
   <artifactId>folio-backend-testing</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
   <description />
 
   <properties>

--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/KeycloakContainerExtension.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/KeycloakContainerExtension.java
@@ -18,7 +18,7 @@ import org.keycloak.representations.idm.PartialImportRepresentation;
 public class KeycloakContainerExtension implements BeforeAllCallback, AfterAllCallback {
 
   @SuppressWarnings("resource")
-  private static final KeycloakContainer CONTAINER = new KeycloakContainer("quay.io/keycloak/keycloak:23.0.3")
+  private static final KeycloakContainer CONTAINER = new KeycloakContainer("quay.io/keycloak/keycloak:23.0.6")
     .withFeaturesEnabled("scripts", "token-exchange", "admin-fine-grained-authz")
     .withProviderLibsFrom(List.of(readToFile("keycloak/folio-scripts.jar", "folio-scripts", ".jar")));
 

--- a/folio-security/pom.xml
+++ b/folio-security/pom.xml
@@ -9,13 +9,13 @@
 
   <name>folio-security</name>
   <artifactId>folio-security</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
 
   <properties>
     <spring-cloud-bom.version>2023.0.0</spring-cloud-bom.version>
-    <keycloak-admin-client.version>23.0.4</keycloak-admin-client.version>
+    <keycloak-admin-client.version>23.0.6</keycloak-admin-client.version>
     <jwks-rsa.version>0.22.1</jwks-rsa.version>
-    <folio-backend-testing.version>1.2.0-SNAPSHOT</folio-backend-testing.version>
+    <folio-backend-testing.version>1.3.0-SNAPSHOT</folio-backend-testing.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### Purpose
Upgrade Keycloak c to v23.0.6

### Approach
_How does this change fulfill the purpose?_

### TODOs and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
