### PR TITLE
MGRAPPS-8 Adjust authorization for routes with prefixes

### DIFF
--- a/folio-security/src/main/java/org/folio/security/integration/authtoken/configuration/OkapiSecurityConfiguration.java
+++ b/folio-security/src/main/java/org/folio/security/integration/authtoken/configuration/OkapiSecurityConfiguration.java
@@ -19,6 +19,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.openfeign.FeignClientsConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.env.Environment;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.web.util.UrlPathHelper;
 
@@ -41,12 +42,12 @@ public class OkapiSecurityConfiguration {
 
   @Bean
   public AuthorizationService authorizationService(AuthtokenClient authtokenClient,
-    InternalModuleDescriptorProvider internalModuleDescriptorProvider,
-    RoutingEntryMatcher routingEntryMatcher,
-    UrlPathHelper urlPathHelper) {
-    return new OkapiAuthorizationService(urlPathHelper, routingEntryMatcher, internalModuleDescriptorProvider,
-      authtokenClient,
-      properties.getUrl());
+    InternalModuleDescriptorProvider internalModuleDescriptorProvider, RoutingEntryMatcher routingEntryMatcher,
+    UrlPathHelper urlPathHelper, Environment environment) {
+    var okapiAuthorizationService = new OkapiAuthorizationService(urlPathHelper, routingEntryMatcher,
+      internalModuleDescriptorProvider, authtokenClient, properties.getUrl());
+    okapiAuthorizationService.setEnvironment(environment);
+    return okapiAuthorizationService;
   }
 
   @Bean

--- a/folio-security/src/main/java/org/folio/security/integration/authtoken/service/OkapiAuthorizationService.java
+++ b/folio-security/src/main/java/org/folio/security/integration/authtoken/service/OkapiAuthorizationService.java
@@ -17,7 +17,7 @@ import org.folio.security.exception.ForbiddenException;
 import org.folio.security.exception.NotAuthorizedException;
 import org.folio.security.exception.RoutingEntryMatchingException;
 import org.folio.security.integration.authtoken.client.AuthtokenClient;
-import org.folio.security.service.AuthorizationService;
+import org.folio.security.service.AbstractAuthorizationService;
 import org.folio.security.service.InternalModuleDescriptorProvider;
 import org.folio.security.service.RoutingEntryMatcher;
 import org.springframework.security.core.Authentication;
@@ -25,7 +25,7 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
 import org.springframework.web.util.UrlPathHelper;
 
 @RequiredArgsConstructor
-public class OkapiAuthorizationService implements AuthorizationService {
+public class OkapiAuthorizationService extends AbstractAuthorizationService {
 
   private static final String COMMA = ",";
 
@@ -37,7 +37,7 @@ public class OkapiAuthorizationService implements AuthorizationService {
 
   @Override
   public Authentication authorize(HttpServletRequest request, String token) {
-    var path = urlPathHelper.getPathWithinApplication(request);
+    var path = updatePath(urlPathHelper.getPathWithinApplication(request));
     var method = request.getMethod();
 
     var routingEntry = routingEntryMatcher.lookup(method, path)

--- a/folio-security/src/main/java/org/folio/security/integration/keycloak/configuration/KeycloakSecurityConfiguration.java
+++ b/folio-security/src/main/java/org/folio/security/integration/keycloak/configuration/KeycloakSecurityConfiguration.java
@@ -19,6 +19,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.openfeign.FeignClientsConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.env.Environment;
 import org.springframework.core.io.ResourceLoader;
 
 @ConditionalOnProperty({"application.security.enabled", "application.keycloak.enabled"})
@@ -38,8 +39,10 @@ public class KeycloakSecurityConfiguration {
 
   @Bean
   public KeycloakAuthorizationService authorizationService(KeycloakAuthClient keycloakClient,
-    RoutingEntryMatcher routingEntryMatcher, KeycloakTokenValidator tokenValidator) {
-    return new KeycloakAuthorizationService(keycloakClient, routingEntryMatcher, tokenValidator, properties);
+    RoutingEntryMatcher routingEntryMatcher, KeycloakTokenValidator tokenValidator, Environment environment) {
+    var service = new KeycloakAuthorizationService(keycloakClient, routingEntryMatcher, tokenValidator, properties);
+    service.setEnvironment(environment);
+    return service;
   }
 
   @Bean

--- a/folio-security/src/main/java/org/folio/security/integration/keycloak/service/KeycloakAuthorizationService.java
+++ b/folio-security/src/main/java/org/folio/security/integration/keycloak/service/KeycloakAuthorizationService.java
@@ -18,7 +18,7 @@ import org.folio.security.exception.NotAuthorizedException;
 import org.folio.security.exception.RoutingEntryMatchingException;
 import org.folio.security.integration.keycloak.client.KeycloakAuthClient;
 import org.folio.security.integration.keycloak.configuration.properties.KeycloakProperties;
-import org.folio.security.service.AuthorizationService;
+import org.folio.security.service.AbstractAuthorizationService;
 import org.folio.security.service.RoutingEntryMatcher;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
@@ -26,7 +26,7 @@ import org.springframework.web.util.UrlPathHelper;
 
 @Log4j2
 @RequiredArgsConstructor
-public class KeycloakAuthorizationService implements AuthorizationService {
+public class KeycloakAuthorizationService extends AbstractAuthorizationService {
 
   private final UrlPathHelper urlPathHelper = new UrlPathHelper();
   private final KeycloakAuthClient keycloakClient;
@@ -36,7 +36,7 @@ public class KeycloakAuthorizationService implements AuthorizationService {
 
   @Override
   public Authentication authorize(HttpServletRequest request, String token) {
-    var path = urlPathHelper.getPathWithinApplication(request);
+    var path = updatePath(urlPathHelper.getPathWithinApplication(request));
     var method = request.getMethod();
     var routingEntry = routingEntryMatcher.lookup(method, path)
       .orElseThrow(() -> new RoutingEntryMatchingException("Unable to resolve routing entry for path: " + path));

--- a/folio-security/src/main/java/org/folio/security/service/AbstractAuthorizationService.java
+++ b/folio-security/src/main/java/org/folio/security/service/AbstractAuthorizationService.java
@@ -1,0 +1,29 @@
+package org.folio.security.service;
+
+import lombok.Setter;
+import org.folio.security.exception.RoutingEntryMatchingException;
+import org.springframework.core.env.Environment;
+
+@Setter
+public abstract class AbstractAuthorizationService implements AuthorizationService {
+
+  public static final String ROUTER_PREFIX_PROPERTY = "application.router.path-prefix";
+
+  protected Environment environment;
+
+  protected String updatePath(String path) {
+    var routerPrefix = environment.getProperty(ROUTER_PREFIX_PROPERTY, "").trim();
+    var prefix = routerPrefix.startsWith("/") ? routerPrefix : "/" + routerPrefix;
+
+    if (prefix.equals("/")) {
+      return path;
+    }
+
+    if (path.startsWith(prefix)) {
+      return path.substring(prefix.length());
+    }
+
+    var errorMessage = String.format("Route is not found for path: '%s'", prefix);
+    throw new RoutingEntryMatchingException(errorMessage);
+  }
+}

--- a/folio-security/src/test/java/org/folio/security/filter/AuthorizationFilterTest.java
+++ b/folio-security/src/test/java/org/folio/security/filter/AuthorizationFilterTest.java
@@ -33,6 +33,7 @@ class AuthorizationFilterTest {
 
   private static final String OKAPI_TOKEN = "test";
   private static final String BEARER_OKAPI_TOKEN = "Bearer " + OKAPI_TOKEN;
+
   @Mock private FilterChain filterChain;
   @Mock private HttpServletRequest request;
   @Mock private HttpServletResponse response;


### PR DESCRIPTION
### Purpose
Fixes an issue with routes with prefixes, introduced in mgr-components and deprecated methods in Security configuration

### Approach
- Fix an issue for routes with prefix by using commong `application.router.path-prefix` variable
- Refactor [SecurityConfiguration.java](https://github.com/folio-org/applications-poc-tools/compare/feature/MGRAPPS-8?expand=1#diff-ffbce3315501d2aad060128a9593632a7c67c384b9dadb0831b0790aea7d632a) by removing all deprecated methods

### TODOs and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
