### PR TITLE
APPPOCTOOL-7 Add network alias for WireMockExtension.java

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @folio-org/eureka

--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/WireMockExtension.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/WireMockExtension.java
@@ -62,7 +62,7 @@ public class WireMockExtension implements BeforeAllCallback, AfterAllCallback {
   public void beforeAll(ExtensionContext context) {
     runContainer();
 
-    String wmUrl = getUrlForExposedPort(WM_DOCKER_PORT);
+    String wmUrl = getUrlForExposedPort();
     setProperty(WM_URL_PROPERTY, wmUrl);
 
     setSystemVarsToWireMockUrl(context, wmUrl);
@@ -82,7 +82,7 @@ public class WireMockExtension implements BeforeAllCallback, AfterAllCallback {
     if (!WM_CONTAINER.isRunning()) {
       WM_CONTAINER.start();
 
-      var wmUrl = getUrlForExposedPort(WM_DOCKER_PORT);
+      var wmUrl = getUrlForExposedPort();
       log.info("Wire mock server started [url: {}]", wmUrl);
 
       int hostPort = WM_CONTAINER.getMappedPort(WM_DOCKER_PORT);
@@ -130,7 +130,7 @@ public class WireMockExtension implements BeforeAllCallback, AfterAllCallback {
     }
   }
 
-  private static String getUrlForExposedPort(int port) {
-    return String.format("http://%s:%s", WM_CONTAINER.getHost(), WM_CONTAINER.getMappedPort(port));
+  private static String getUrlForExposedPort() {
+    return String.format("http://%s:%s", WM_CONTAINER.getHost(), WM_CONTAINER.getMappedPort(WM_DOCKER_PORT));
   }
 }

--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/WireMockExtension.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/WireMockExtension.java
@@ -62,7 +62,7 @@ public class WireMockExtension implements BeforeAllCallback, AfterAllCallback {
   public void beforeAll(ExtensionContext context) {
     runContainer();
 
-    String wmUrl = getUrlForExposedPort();
+    var wmUrl = getUrlForExposedPort();
     setProperty(WM_URL_PROPERTY, wmUrl);
 
     setSystemVarsToWireMockUrl(context, wmUrl);


### PR DESCRIPTION
### Purpose
Externizes docker port and network alias for Wiremock container to be accessible for other containers in network

### Approach
- Expose docker port and network alias for Wiremock container

### TODOs and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
