### PR TITLE
KONG-6 Kong timeouts should be extended

### DIFF
--- a/folio-integration-kong/src/main/java/org/folio/tools/kong/configuration/KongConfigurationProperties.java
+++ b/folio-integration-kong/src/main/java/org/folio/tools/kong/configuration/KongConfigurationProperties.java
@@ -26,4 +26,26 @@ public class KongConfigurationProperties {
    * Defines if module must be registered.
    */
   private boolean registerModule;
+
+  /**
+   * The number of retries to execute upon failure to proxy.
+   */
+  private Integer retries;
+
+  /**
+   * The timeout in milliseconds for establishing a connection from Kong to upstream service.
+   */
+  private Integer connectTimeout;
+
+  /**
+   * The timeout in milliseconds between two successive write operations for transmitting a request from Kong
+   * to the upstream service.
+   */
+  private Integer writeTimeout;
+
+  /**
+   * The timeout in milliseconds between two successive read operations for transmitting a request from Kong
+   * to the upstream service.
+   */
+  private Integer readTimeout;
 }

--- a/folio-integration-kong/src/main/java/org/folio/tools/kong/model/Service.java
+++ b/folio-integration-kong/src/main/java/org/folio/tools/kong/model/Service.java
@@ -22,13 +22,13 @@ public class Service {
   private Boolean enabled = true;
 
   @JsonProperty("connect_timeout")
-  private Integer connectTimeout = 60000;
+  private Integer connectTimeout;
 
   @JsonProperty("write_timeout")
-  private Integer writeTimeout = 60000;
+  private Integer writeTimeout;
 
   @JsonProperty("read_timeout")
-  private Integer readTimeout = 60000;
+  private Integer readTimeout;
 
   @JsonProperty("client_certificate")
   private Identifier clientCertificate;

--- a/folio-integration-kong/src/main/java/org/folio/tools/kong/service/KongModuleRegistrar.java
+++ b/folio-integration-kong/src/main/java/org/folio/tools/kong/service/KongModuleRegistrar.java
@@ -22,16 +22,22 @@ public class KongModuleRegistrar {
   private final ObjectMapper objectMapper;
   private final ResourceLoader resourceLoader;
   private final KongGatewayService kongGatewayService;
-  private final KongConfigurationProperties kongConfigurationProperties;
+  private final KongConfigurationProperties properties;
 
   @EventListener(ApplicationReadyEvent.class)
   public void registerRoutes() {
     var moduleDescriptor = getModuleDescriptor();
     var moduleId = moduleDescriptor.getId();
-    var moduleUrl = kongConfigurationProperties.getModuleSelfUrl();
+    var moduleUrl = properties.getModuleSelfUrl();
 
     log.info("Self-registering service in Kong: moduleId = {}, url = {}", moduleId, moduleUrl);
-    kongGatewayService.upsertService(new Service().name(moduleId).url(moduleUrl));
+    kongGatewayService.upsertService(
+      new Service().name(moduleId).url(moduleUrl)
+        .connectTimeout(properties.getConnectTimeout())
+        .readTimeout(properties.getReadTimeout())
+        .writeTimeout(properties.getWriteTimeout())
+        .retries(properties.getRetries())
+    );
     kongGatewayService.updateRoutes(null, singletonList(moduleDescriptor));
   }
 

--- a/folio-integration-kong/src/test/java/org/folio/tools/kong/service/KongModuleRegistrarTest.java
+++ b/folio-integration-kong/src/test/java/org/folio/tools/kong/service/KongModuleRegistrarTest.java
@@ -48,8 +48,17 @@ class KongModuleRegistrarTest {
     var path = "classpath:descriptors/ModuleDescriptor.json";
     var moduleUrl = "https://test-module:8081";
     var serviceName = "test-service";
+    var connectTimeout = 60000;
+    var readTimeout = 60000;
+    var writeTimeout = 60000;
+    var retries = 5;
 
     when(kongConfigurationProperties.getModuleSelfUrl()).thenReturn(moduleUrl);
+    when(kongConfigurationProperties.getConnectTimeout()).thenReturn(connectTimeout);
+    when(kongConfigurationProperties.getReadTimeout()).thenReturn(readTimeout);
+    when(kongConfigurationProperties.getWriteTimeout()).thenReturn(writeTimeout);
+    when(kongConfigurationProperties.getRetries()).thenReturn(retries);
+
     when(resourceLoader.getResource(path)).thenReturn(resource);
     when(resource.getInputStream()).thenReturn(inputStream);
     when(objectMapper.readValue(inputStream, ModuleDescriptor.class)).thenReturn(moduleDescriptor);
@@ -57,7 +66,11 @@ class KongModuleRegistrarTest {
 
     kongModuleRegistrar.registerRoutes();
 
-    var expectedService = new Service().name(serviceName).url(moduleUrl);
+    var expectedService = new Service().name(serviceName).url(moduleUrl)
+      .connectTimeout(connectTimeout)
+      .writeTimeout(writeTimeout)
+      .readTimeout(readTimeout)
+      .retries(retries);
     verify(kongGatewayService).upsertService(expectedService);
     verify(kongGatewayService).updateRoutes(null, List.of(moduleDescriptor));
   }


### PR DESCRIPTION
### Purpose
Kong timeout should be extended - can't enable all apps for tenants now that mgr-tenant-entitlements is now accessed via Kong.  We get a 504 gateway timeout when enabling applications.

US: [KONG-6](https://folio-org.atlassian.net/browse/KONG-6)

### Approach
* add new configuration properties for retries/connectTimeout/writeTimeout/readTimeout to `KongConfigurationProperties`
* use the properties while population Kong service