### PR TITLE
EUREKA-66 Populate _timer interface routes in Kong

### DIFF
--- a/folio-backend-common/src/main/java/org/folio/common/domain/model/InterfaceDescriptor.java
+++ b/folio-backend-common/src/main/java/org/folio/common/domain/model/InterfaceDescriptor.java
@@ -12,6 +12,7 @@ import org.folio.common.utils.InterfaceComparisonUtils;
 public class InterfaceDescriptor {
 
   public static final String SYSTEM_INTERFACE_TYPE = "system";
+  public static final String TIMER_INTERFACE = "_timer";
 
   private String id;
   private String version;
@@ -160,6 +161,16 @@ public class InterfaceDescriptor {
   @JsonIgnore
   public boolean isSystem() {
     return SYSTEM_INTERFACE_TYPE.equals(this.interfaceType);
+  }
+
+  /**
+   * Checks if interface is a time interface.
+   *
+   * @return true if interface represents timer, false - otherwise.
+   */
+  @JsonIgnore
+  public boolean isTimer() {
+    return TIMER_INTERFACE.equals(this.id);
   }
 
   /**

--- a/folio-backend-common/src/test/java/org/folio/common/domain/model/InterfaceDescriptorTest.java
+++ b/folio-backend-common/src/test/java/org/folio/common/domain/model/InterfaceDescriptorTest.java
@@ -56,4 +56,17 @@ class InterfaceDescriptorTest {
     var comparisonResult = given.isCompatible(interfaceToCompare);
     assertThat(comparisonResult).isEqualTo(expected);
   }
+
+  @ParameterizedTest(name = "[{index}] id=''{0}-{1}'', isTimer={2}")
+  @CsvSource({
+    "_timer, 1.0, true",
+    "_TimeR, 1.0, false",
+    "timer, 1.0, false",
+    "test-interface, 1.0, false"
+  })
+  void isTimer_parameterized(String name, String version, boolean expected) {
+    var given = new InterfaceDescriptor(name, version);
+    var actual = given.isTimer();
+    assertThat(actual).isEqualTo(expected);
+  }
 }

--- a/folio-integration-kong/src/main/java/org/folio/tools/kong/service/KongGatewayService.java
+++ b/folio-integration-kong/src/main/java/org/folio/tools/kong/service/KongGatewayService.java
@@ -190,7 +190,7 @@ public class KongGatewayService {
 
   private List<Pair<Route, RoutingEntry>> prepareRoutes(InterfaceDescriptor desc, String moduleId, String tenant) {
     var interfaceId = desc.getId() + "-" + desc.getVersion();
-    if (desc.isSystem()) {
+    if (desc.isSystem() && !desc.isTimer()) {
       log.debug("System interface is ignored: tenant={}, moduleId={}, interfaceId={}]", tenant, moduleId, interfaceId);
       return emptyList();
     }


### PR DESCRIPTION
### Purpose
Populate _timer interface routes in Kong so that they become available for mod-scheduler
US: [EUREKA-66](https://folio-org.atlassian.net/browse/EUREKA-66)

### Approach
* do not ignore `_timer` interface handlers while preparing Kong routes to be created/updated in `KongGatewayService`

this is a **TEMPORARY solution**, should be replaced with well defined approach later