### PR TITLE
Ignore empty properties during json serialization

### DIFF
--- a/folio-backend-testing/src/main/java/org/folio/test/TestUtils.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/TestUtils.java
@@ -20,7 +20,7 @@ import org.springframework.test.web.servlet.MvcResult;
 public class TestUtils {
 
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-    .setSerializationInclusion(Include.NON_NULL)
+    .setSerializationInclusion(Include.NON_EMPTY)
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.4</version>
+    <version>3.2.5</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
### Purpose
Ignore empty properties during json serialization. This will cause in particular empty collections to be skipped 

### Approach
* use `Include.NON_EMPTY` instead of `Include.NON_NULL` to configure object mapper in `TestUtils`