### PR TITLE
MGRENTITLE-21 Stop clearing events after get operation

### DIFF
--- a/folio-backend-testing/src/main/java/org/folio/test/FakeKafkaConsumer.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/FakeKafkaConsumer.java
@@ -70,8 +70,6 @@ public class FakeKafkaConsumer {
   public static <T> List<ConsumerRecord<String, T>> getEvents(String topic,
     Function<ConsumerRecord<String, String>, ConsumerRecord<String, T>> consumerRecordValueMapper) {
     var foundEvents = EVENTS.getOrDefault(topic, emptyList());
-    // clear events, since they are consumed for assertion
-    EVENTS.remove(topic);
     return foundEvents.stream().map(consumerRecordValueMapper).collect(toList());
   }
 
@@ -89,8 +87,8 @@ public class FakeKafkaConsumer {
   }
 
   private KafkaMessageListenerContainer<String, String> createContainer(String topic) {
-    var consumer = new DefaultKafkaConsumerFactory<String, String>(kafkaProperties.buildConsumerProperties());
-    log.info("Consumer config: {}", kafkaProperties.buildConsumerProperties());
+    var consumer = new DefaultKafkaConsumerFactory<String, String>(kafkaProperties.buildConsumerProperties(null));
+    log.info("Consumer config: {}", kafkaProperties.buildConsumerProperties(null));
 
     configureDeserializers(consumer);
 


### PR DESCRIPTION
### Purpose
Don't remove events after each retrieve operation, cause it leads to inconsistent test runs

### Approach
- Don't remove events after each retrieve operation
- Replace deprecated methods

### TODOs and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
