### PR TITLE
APPPOCTOOL-20: Fix SSLContext creation for the FIPS mode

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 import org.jenkinsci.plugins.workflow.libs.Library
-@Library('jenkins-pipeline-libs@US1270433') _
+@Library('folio_jenkins_shared_libs@US1270433') _
 buildMvn {
   publishModDescriptor = 'no'
   mvnDeploy = 'yes'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+import org.jenkinsci.plugins.workflow.libs.Library
+@Library('jenkins-pipeline-libs@US1270433') _
 buildMvn {
   publishModDescriptor = 'no'
   mvnDeploy = 'yes'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,3 @@
-import org.jenkinsci.plugins.workflow.libs.Library
-@Library('folio_jenkins_shared_libs@US1270433') _
 buildMvn {
   publishModDescriptor = 'no'
   mvnDeploy = 'yes'

--- a/folio-security/src/main/java/org/folio/security/integration/keycloak/utils/ClientBuildUtils.java
+++ b/folio-security/src/main/java/org/folio/security/integration/keycloak/utils/ClientBuildUtils.java
@@ -1,19 +1,14 @@
 package org.folio.security.integration.keycloak.utils;
 
 import static jakarta.ws.rs.client.ClientBuilder.newBuilder;
-import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.stripToNull;
 import static org.apache.http.conn.ssl.NoopHostnameVerifier.INSTANCE;
-import static org.apache.http.ssl.SSLContextBuilder.create;
-import static org.springframework.util.ResourceUtils.getFile;
 
-import java.security.KeyStore;
-import javax.net.ssl.SSLContext;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.ssl.SSLInitializationException;
 import org.folio.common.configuration.properties.TlsProperties;
+import org.folio.common.utils.FeignClientTlsUtils;
 import org.folio.security.integration.keycloak.configuration.properties.KeycloakProperties;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.keycloak.admin.client.Keycloak;
@@ -40,25 +35,12 @@ public class ClientBuildUtils {
     return builder.build();
   }
 
-  public static SSLContext buildSslContext(TlsProperties tls) {
-    var trustStorePath = requireNonNull(tls.getTrustStorePath(), "Trust store path is not defined");
-    try {
-      return create()
-        .loadTrustMaterial(getFile(trustStorePath), tls.getTrustStorePassword().toCharArray())
-        .setKeyStoreType(isBlank(tls.getTrustStoreType()) ? KeyStore.getDefaultType() : tls.getTrustStoreType())
-        .build();
-    } catch (Exception e) {
-      log.error("Error creating SSL context", e);
-      throw new SSLInitializationException("Error creating SSL context", e);
-    }
-  }
-
   private static ResteasyClient buildResteasyClient(TlsProperties tls) {
     var clientBuilder = newBuilder().hostnameVerifier(INSTANCE);
     if (isBlank(tls.getTrustStorePath())) {
       log.debug("Creating ResteasyClient for Public Trusted Certificates");
       return (ResteasyClient) clientBuilder.build();
     }
-    return (ResteasyClient) clientBuilder.sslContext(buildSslContext(tls)).build();
+    return (ResteasyClient) clientBuilder.sslContext(FeignClientTlsUtils.buildSslContext(tls)).build();
   }
 }

--- a/folio-security/src/test/java/org/folio/security/integration/keycloak/utils/ClientBuildUtilsTest.java
+++ b/folio-security/src/test/java/org/folio/security/integration/keycloak/utils/ClientBuildUtilsTest.java
@@ -2,10 +2,7 @@ package org.folio.security.integration.keycloak.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.security.integration.keycloak.utils.ClientBuildUtils.buildKeycloakAdminClient;
-import static org.folio.security.integration.keycloak.utils.ClientBuildUtils.buildSslContext;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.apache.http.ssl.SSLInitializationException;
 import org.folio.common.configuration.properties.TlsProperties;
 import org.folio.security.integration.keycloak.configuration.properties.KeycloakAdminProperties;
 import org.folio.security.integration.keycloak.configuration.properties.KeycloakClientProperties;
@@ -39,22 +36,6 @@ class ClientBuildUtilsTest {
     var keycloakAdminClient = buildKeycloakAdminClient("secretPassword", keycloakProperties);
 
     assertThat(keycloakAdminClient).isNotNull();
-  }
-
-  @Test
-  void buildSslContext_positive() {
-    var tls = new TlsProperties();
-    tls.setTrustStorePath("classpath:certificates/test.truststore.jks");
-    tls.setTrustStorePassword("secretpassword");
-    tls.setTrustStoreType("JKS");
-    assertThat(buildSslContext(tls)).isNotNull();
-  }
-
-  @Test
-  void buildSslContext_negative() {
-    var tls = new TlsProperties();
-    tls.setTrustStorePath("");
-    assertThrows(SSLInitializationException.class, () -> buildSslContext(tls));
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Fix SSLContext creation for the FIPS mode

### Approach
Apply `buildSslContext` from `FeignClientTlsUtils` since `SSlContextBuilder` does not propagate the type and set the default one PKCS12 instead

### TODOs and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
