### PR TITLE
APPPOCTOOL-16 Upgrade keycloak to v25.0.1

### DIFF
--- a/folio-backend-testing/pom.xml
+++ b/folio-backend-testing/pom.xml
@@ -17,7 +17,7 @@
     <jsonassert.version>1.5.1</jsonassert.version>
     <jjwt.version>0.12.5</jjwt.version>
     <apache-commons-lang3.version>3.14.0</apache-commons-lang3.version>
-    <testcontainers-keycloak.version>3.3.1</testcontainers-keycloak.version>
+    <testcontainers-keycloak.version>3.4.0</testcontainers-keycloak.version>
   </properties>
 
   <dependencies>

--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/KeycloakContainerExtension.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/KeycloakContainerExtension.java
@@ -14,6 +14,7 @@ import dasniko.testcontainers.keycloak.KeycloakContainer;
 import java.util.List;
 import javax.net.ssl.SSLContext;
 import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.ssl.SSLInitializationException;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -27,7 +28,7 @@ import org.keycloak.representations.idm.PartialImportRepresentation;
 @Log4j2
 public class KeycloakContainerExtension implements BeforeAllCallback, AfterAllCallback {
 
-  private static final String KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:23.0.7";
+  private static final String KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:25.0.1";
   private static final String REALM_JSON = "json/keycloak/master-realm.json";
   private static final String IMPORTED_CLIENT_ID = "folio-backend-admin-client";
   private static final String IMPORTED_CLIENT_SECRET = "supersecret";
@@ -99,6 +100,8 @@ public class KeycloakContainerExtension implements BeforeAllCallback, AfterAllCa
   private static KeycloakContainer keycloakContainer() {
     return new KeycloakContainer(KEYCLOAK_IMAGE)
       .withFeaturesEnabled("scripts", "token-exchange", "admin-fine-grained-authz")
+      .withAdminUsername("keycloak-test-admin")
+      .withAdminPassword(RandomStringUtils.random(20, true, true))
       .withProviderLibsFrom(List.of(readToFile("keycloak/folio-scripts.jar", "folio-scripts", ".jar")))
       .useTlsKeystore(SSL_KEYSTORE_PATH, SSL_KEYSTORE_PASSWORD);
   }

--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/KeycloakExecutionListener.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/KeycloakExecutionListener.java
@@ -10,18 +10,18 @@ import static org.springframework.test.context.util.TestContextResourceUtils.con
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.AnnotatedElement;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.io.IOUtils;
 import org.folio.test.extensions.KeycloakRealms;
 import org.folio.test.extensions.KeycloakRealmsGroup;
-import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.springframework.core.io.Resource;
 import org.springframework.lang.NonNull;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
-import org.springframework.util.Assert;
 
 @Log4j2
 public class KeycloakExecutionListener implements TestExecutionListener {
@@ -29,39 +29,61 @@ public class KeycloakExecutionListener implements TestExecutionListener {
   @Override
   public void beforeTestMethod(@NonNull TestContext ctx) {
     var adminClient = getKeycloakAdminClient();
-    getAnnotationsFor(ctx.getTestClass()).forEach(realmPath -> importKeycloakRealm(realmPath, adminClient, ctx));
-    getAnnotationsFor(ctx.getTestMethod()).forEach(realmPath -> importKeycloakRealm(realmPath, adminClient, ctx));
+    var annotatedRealms = getAnnotatedRealms(ctx);
+    var createdRealms = new ArrayList<String>();
+    for (var realmRepresentation : annotatedRealms) {
+      log.info("Importing test realm: {}", realmRepresentation.getRealm());
+      createdRealms.add(realmRepresentation.getRealm());
+      adminClient.realms().create(realmRepresentation);
+    }
+
+    ctx.setAttribute(getImportedRealmsAttributeName(), createdRealms);
   }
 
   @Override
   public void afterTestMethod(@NonNull TestContext ctx) {
     var keycloak = getKeycloakAdminClient();
-    var realms = keycloak.realms().findAll();
-    realms.stream()
-      .map(RealmRepresentation::getRealm)
-      .filter(realm -> !realm.equals("master"))
-      .forEach(realm -> {
-        log.info("Removing test realm: {}", realm);
-        keycloak.realms().realm(realm).remove();
-      });
+    var importedRawRealmNames = ctx.getAttribute(getImportedRealmsAttributeName());
+
+    //noinspection rawtypes
+    if (importedRawRealmNames instanceof List importedRealmNamesList) {
+      for (var rawRealmName : importedRealmNamesList) {
+        if (rawRealmName instanceof String realmName) {
+          keycloak.realm(realmName).remove();
+        }
+      }
+    }
   }
 
   private static Set<KeycloakRealms> getAnnotationsFor(AnnotatedElement element) {
     return getMergedRepeatableAnnotations(element, KeycloakRealms.class, KeycloakRealmsGroup.class);
   }
 
-  private static void importKeycloakRealm(KeycloakRealms keycloakRealms, Keycloak keycloak, TestContext ctx) {
-    var realms = keycloakRealms.realms();
-    Assert.notEmpty(realms, "Empty realms are not allowed");
+  private static List<RealmRepresentation> getAnnotatedRealms(TestContext testContext) {
+    var realmsMap = new ArrayList<RealmRepresentation>();
+    for (var keycloakRealms : getAnnotationsFor(testContext.getTestClass())) {
+      realmsMap.addAll(getRealmRepresentations(keycloakRealms, testContext));
+    }
 
-    var classpathResourcePaths = convertToClasspathResourcePaths(ctx.getTestClass(), realms);
+    for (var keycloakRealms : getAnnotationsFor(testContext.getTestMethod())) {
+      realmsMap.addAll(getRealmRepresentations(keycloakRealms, testContext));
+    }
+
+    return realmsMap;
+  }
+
+  private static List<RealmRepresentation> getRealmRepresentations(KeycloakRealms keycloakRealms, TestContext ctx) {
+    var realmPaths = keycloakRealms.realms();
+    var classpathResourcePaths = convertToClasspathResourcePaths(ctx.getTestClass(), realmPaths);
     var resources = convertToResourceList(ctx.getApplicationContext(), classpathResourcePaths);
+    var realms = new ArrayList<RealmRepresentation>();
     for (var resource : resources) {
       var realmJson = readAsString(resource);
       var realmRepresentation = parse(realmJson, RealmRepresentation.class);
-      log.info("Importing test realm: {}", realmRepresentation.getRealm());
-      keycloak.realms().create(realmRepresentation);
+      realms.add(realmRepresentation);
     }
+
+    return realms;
   }
 
   private static String readAsString(Resource resource) {
@@ -70,5 +92,9 @@ public class KeycloakExecutionListener implements TestExecutionListener {
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to read resource as string: " + resource.getFilename(), e);
     }
+  }
+
+  private String getImportedRealmsAttributeName() {
+    return this.getClass() + "#kc-imported-realms";
   }
 }

--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/KeycloakExecutionListener.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/KeycloakExecutionListener.java
@@ -7,6 +7,7 @@ import static org.springframework.core.annotation.AnnotatedElementUtils.getMerge
 import static org.springframework.test.context.util.TestContextResourceUtils.convertToClasspathResourcePaths;
 import static org.springframework.test.context.util.TestContextResourceUtils.convertToResourceList;
 
+import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.AnnotatedElement;
@@ -49,7 +50,11 @@ public class KeycloakExecutionListener implements TestExecutionListener {
     if (importedRawRealmNames instanceof List importedRealmNamesList) {
       for (var rawRealmName : importedRealmNamesList) {
         if (rawRealmName instanceof String realmName) {
-          keycloak.realm(realmName).remove();
+          try {
+            keycloak.realm(realmName).remove();
+          } catch (NotFoundException e) {
+            // nothing to do, cause realm is not found
+          }
         }
       }
     }

--- a/folio-security/pom.xml
+++ b/folio-security/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <spring-cloud-bom.version>2023.0.2</spring-cloud-bom.version>
-    <keycloak-admin-client.version>23.0.7</keycloak-admin-client.version>
+    <keycloak-admin-client.version>25.0.1</keycloak-admin-client.version>
     <jwks-rsa.version>0.22.1</jwks-rsa.version>
 
     <sonar.exclusions>


### PR DESCRIPTION
### Purpose
Upgrades keycloak test container and keycloak-admin-client to v25.0.1

### Approach
- Upgrade keycloak admin client version to `25.0.1`
- Upgrade keycloak test container to `25.0.1`

### TODOs and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
