### PR TITLE
MODLOGINKC-19: make non tenant topics optional

### DIFF
--- a/folio-integration-kafka/src/main/java/org/folio/integration/kafka/KafkaTopicConfiguration.java
+++ b/folio-integration-kafka/src/main/java/org/folio/integration/kafka/KafkaTopicConfiguration.java
@@ -1,6 +1,6 @@
 package org.folio.integration.kafka;
 
-import static org.apache.commons.collections4.CollectionUtils.isEmpty;
+import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 import static org.folio.integration.kafka.KafkaUtils.getEnvTopicName;
 
 import jakarta.annotation.PostConstruct;
@@ -18,12 +18,7 @@ public class KafkaTopicConfiguration {
 
   @PostConstruct
   public void createTopics() {
-    if (isEmpty(folioKafkaProperties.getTopics())) {
-      log.debug("No topics to create");
-      return;
-    }
-
-    for (var topic : folioKafkaProperties.getTopics()) {
+    for (var topic : emptyIfNull(folioKafkaProperties.getTopics())) {
       var topicName = getEnvTopicName(topic.getName());
       var newTopic = KafkaUtils.createTopic(topicName, topic.getNumPartitions(), topic.getReplicationFactor());
       kafkaAdminService.createTopic(newTopic);

--- a/folio-integration-kafka/src/main/java/org/folio/integration/kafka/KafkaTopicConfiguration.java
+++ b/folio-integration-kafka/src/main/java/org/folio/integration/kafka/KafkaTopicConfiguration.java
@@ -1,5 +1,6 @@
 package org.folio.integration.kafka;
 
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.folio.integration.kafka.KafkaUtils.getEnvTopicName;
 
 import jakarta.annotation.PostConstruct;
@@ -17,6 +18,11 @@ public class KafkaTopicConfiguration {
 
   @PostConstruct
   public void createTopics() {
+    if (isEmpty(folioKafkaProperties.getTopics())) {
+      log.debug("No topics to create");
+      return;
+    }
+
     for (var topic : folioKafkaProperties.getTopics()) {
       var topicName = getEnvTopicName(topic.getName());
       var newTopic = KafkaUtils.createTopic(topicName, topic.getNumPartitions(), topic.getReplicationFactor());

--- a/folio-integration-kafka/src/test/java/org/folio/integration/kafka/KafkaTopicConfigurationTest.java
+++ b/folio-integration-kafka/src/test/java/org/folio/integration/kafka/KafkaTopicConfigurationTest.java
@@ -1,6 +1,7 @@
 package org.folio.integration.kafka;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -33,5 +34,14 @@ class KafkaTopicConfigurationTest {
     verify(kafkaAdminService).createTopic(new NewTopic("folio.topic1", Optional.of(10), Optional.empty()));
     verify(kafkaAdminService).createTopic(new NewTopic("folio.topic2", Optional.empty(), Optional.of((short) 2)));
     verify(kafkaAdminService).createTopic(new NewTopic("folio.topic3", Optional.of(30), Optional.of((short) -1)));
+  }
+
+  @Test
+  void createTopics_positive_topicsEmpty() {
+    when(folioKafkaProperties.getTopics()).thenReturn(null);
+
+    kafkaTopicConfiguration.createTopics();
+
+    verifyNoInteractions(kafkaAdminService);
   }
 }


### PR DESCRIPTION
### Purpose
https://folio-org.atlassian.net/browse/MODLOGINKC-19
There are modules with no non-tenant topics. It should be optional.

### Approach
- make non-tenant topics creation optional

### TODOs and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
