### PR TITLE
APPPOCTOOL-22 Create SSM Client on every call to avoid connection pool shutdown

### DIFF
--- a/folio-secret-store/folio-secret-store-common/src/main/java/org/folio/tools/store/SecureStoreFactory.java
+++ b/folio-secret-store/folio-secret-store-common/src/main/java/org/folio/tools/store/SecureStoreFactory.java
@@ -21,7 +21,7 @@ public final class SecureStoreFactory {
 
     secureStore = switch (type) {
       case VaultStore.TYPE -> new VaultStore(props);
-      case AwsStore.TYPE -> new AwsStore(props);
+      case AwsStore.TYPE -> AwsStore.create(props);
       default -> new EphemeralStore(props);
     };
 

--- a/folio-secret-store/folio-secret-store-common/src/main/java/org/folio/tools/store/impl/AwsStore.java
+++ b/folio-secret-store/folio-secret-store-common/src/main/java/org/folio/tools/store/impl/AwsStore.java
@@ -1,163 +1,78 @@
 package org.folio.tools.store.impl;
 
 import static java.lang.Boolean.TRUE;
-import static java.lang.Boolean.parseBoolean;
-import static java.util.Objects.nonNull;
 import static software.amazon.awssdk.services.ssm.model.ParameterType.SECURE_STRING;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.security.KeyStore;
 import java.util.Properties;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.apache.http.ssl.SSLInitializationException;
-import org.apache.http.util.Asserts;
 import org.folio.tools.store.SecureStore;
 import org.folio.tools.store.exception.NotFoundException;
 import org.folio.tools.store.properties.AwsConfigProperties;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
-import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
-import software.amazon.awssdk.regions.Region;
+import org.folio.tools.store.utils.SsmClientProvider;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
 import software.amazon.awssdk.services.ssm.model.PutParameterRequest;
 
 @Log4j2
+@RequiredArgsConstructor
 public final class AwsStore implements SecureStore {
 
   public static final String TYPE = "AwsSsm";
   public static final String PROP_REGION = "region";
-  public static final String PROP_USE_IAM = "useIAM";
-  public static final String PROP_ECS_CREDENTIALS_PATH = "ecsCredentialsPath";
-  public static final String PROP_ECS_CREDENTIALS_ENDPOINT = "ecsCredentialsEndpoint";
-  public static final String DEFAULT_USE_IAM = "true";
-  public static final String ECS_CREDENTIALS_PATH_VAR = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
 
-  private SsmClient ssmClient;
-
-  public AwsStore(Properties properties) {
-    ssmClient = buildClient(mapPropertiesToAwsConfigProperties(properties));
-  }
-
-  private AwsStore(AwsConfigProperties properties) {
-    ssmClient = buildClient(properties);
-  }
+  private final SsmClientProvider ssmClientProvider;
 
   @Override
   public String get(String clientId, String tenant, String username) {
-    var key = String.format("%s_%s_%s", clientId, tenant, username);
-    var request = GetParameterRequest.builder().name(key).withDecryption(true).build();
-    return getParameter(request);
+    try (var ssmClient = ssmClientProvider.get()) {
+      var key = String.format("%s_%s_%s", clientId, tenant, username);
+      var request = GetParameterRequest.builder().name(key).withDecryption(true).build();
+      return getParameter(ssmClient, request);
+    }
   }
 
   @Override
   public String get(String key) {
-    var request = GetParameterRequest.builder().name(key).withDecryption(true).build();
-    return getParameter(request);
+    try (var ssmClient = ssmClientProvider.get()) {
+      var request = GetParameterRequest.builder().name(key).withDecryption(true).build();
+      return getParameter(ssmClient, request);
+    }
   }
 
   @Override
   public void set(String key, String value) {
-    var request = PutParameterRequest.builder().name(key).value(value).overwrite(TRUE).type(SECURE_STRING).build();
-    ssmClient.putParameter(request);
+    try (var ssmClient = ssmClientProvider.get()) {
+      var request = PutParameterRequest.builder().name(key).value(value).overwrite(TRUE).type(SECURE_STRING).build();
+      ssmClient.putParameter(request);
+    }
   }
 
+  /**
+   * Creates {@link AwsStore} component.
+   *
+   * @param properties - configuration properties
+   * @return created {@link AwsStore} component
+   */
+  public static AwsStore create(Properties properties) {
+    return new AwsStore(new SsmClientProvider(properties));
+  }
+
+  /**
+   * Creates {@link AwsStore} component.
+   *
+   * @param properties - configuration properties
+   * @return created {@link AwsStore} component
+   */
   public static AwsStore create(AwsConfigProperties properties) {
-    return new AwsStore(properties);
+    return new AwsStore(new SsmClientProvider(properties));
   }
 
-  private String getParameter(GetParameterRequest request) {
+  private String getParameter(SsmClient ssmClient, GetParameterRequest request) {
     try {
       return ssmClient.getParameter(request).parameter().value();
     } catch (Exception e) {
       throw new NotFoundException(e);
-    }
-  }
-
-  private SsmClient buildClient(AwsConfigProperties properties) {
-    log.info("Initializing...");
-    var builder = SsmClient.builder();
-    builder.region(Region.of(properties.getRegion()));
-    if (properties.isFipsEnabled()) {
-      builder.httpClient(ApacheHttpClient.builder()
-        .tlsTrustManagersProvider(() -> getTrustManager(properties)).build());
-      builder.fipsEnabled(true);
-    }
-    if (nonNull(properties.getUseIam()) && properties.getUseIam()) {
-      log.info("Using IAM");
-    } else {
-      var awsCredentialsProvider = getAwsCredentialsProvider();
-      log.info("Using {}", awsCredentialsProvider.getClass().getName());
-      builder.credentialsProvider(awsCredentialsProvider);
-      builder.endpointOverride(endpoint(properties));
-    }
-    return builder.build();
-  }
-
-  private TrustManager[] getTrustManager(AwsConfigProperties properties) {
-    Asserts.notBlank(properties.getTrustStorePath(), "Truststore path must not be blank");
-    try {
-      var trustStore = KeyStore.getInstance(properties.getTrustStoreFileType());
-      try (var trustStoreStream = Files.newInputStream(Path.of(properties.getTrustStorePath()).toAbsolutePath())) {
-        trustStore.load(trustStoreStream, properties.getTrustStorePassword().toCharArray());
-      }
-
-      var trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-      trustManagerFactory.init(trustStore);
-      return trustManagerFactory.getTrustManagers();
-    } catch (Exception e) {
-      throw new SSLInitializationException("Error initializing TrustManager", e);
-    }
-  }
-
-  private AwsCredentialsProvider getAwsCredentialsProvider() {
-    AwsCredentialsProvider credProvider;
-    try {
-      credProvider = EnvironmentVariableCredentialsProvider.create();
-      credProvider.resolveCredentials();
-    } catch (Exception e) {
-      try {
-        credProvider = SystemPropertyCredentialsProvider.create();
-        credProvider.resolveCredentials();
-      } catch (Exception e2) {
-        credProvider = ContainerCredentialsProvider.builder().build();
-        credProvider.resolveCredentials();
-      }
-    }
-    return credProvider;
-  }
-
-  private AwsConfigProperties mapPropertiesToAwsConfigProperties(Properties properties) {
-    return AwsConfigProperties.builder()
-      .useIam(parseBoolean(properties.getProperty(PROP_USE_IAM, DEFAULT_USE_IAM)))
-      .region(properties.getProperty(PROP_REGION))
-      .ecsCredentialsPath(properties.getProperty(PROP_ECS_CREDENTIALS_PATH))
-      .ecsCredentialsEndpoint(properties.getProperty(PROP_ECS_CREDENTIALS_ENDPOINT))
-      .build();
-  }
-
-  private static URI endpoint(AwsConfigProperties properties) {
-    var path = properties.getEcsCredentialsPath();
-    if (path == null) {
-      path = System.getenv(ECS_CREDENTIALS_PATH_VAR);
-    }
-    if (path == null) {
-      throw SdkClientException.create("No credentials path was provided and the environment variable "
-        + ECS_CREDENTIALS_PATH_VAR + " is empty");
-    }
-
-    try {
-      return new URI(properties.getEcsCredentialsEndpoint() + path);
-    } catch (URISyntaxException e) {
-      throw SdkClientException.builder().cause(e).build();
     }
   }
 }

--- a/folio-secret-store/folio-secret-store-common/src/main/java/org/folio/tools/store/utils/SsmClientProvider.java
+++ b/folio-secret-store/folio-secret-store-common/src/main/java/org/folio/tools/store/utils/SsmClientProvider.java
@@ -1,0 +1,108 @@
+package org.folio.tools.store.utils;
+
+import static java.lang.Boolean.parseBoolean;
+import static java.util.Objects.nonNull;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.Properties;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import lombok.extern.log4j.Log4j2;
+import org.apache.http.ssl.SSLInitializationException;
+import org.apache.http.util.Asserts;
+import org.folio.tools.store.properties.AwsConfigProperties;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ssm.SsmClient;
+
+@Log4j2
+public class SsmClientProvider {
+
+  public static final String PROP_REGION = "region";
+  public static final String PROP_USE_IAM = "useIAM";
+  public static final String PROP_ECS_CREDENTIALS_PATH = "ecsCredentialsPath";
+  public static final String PROP_ECS_CREDENTIALS_ENDPOINT = "ecsCredentialsEndpoint";
+  public static final String DEFAULT_USE_IAM = "true";
+  public static final String ECS_CREDENTIALS_PATH_VAR = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
+
+  private final AwsConfigProperties properties;
+
+  public SsmClientProvider(Properties properties) {
+    this.properties = mapPropertiesToAwsConfigProperties(properties);
+  }
+
+  public SsmClientProvider(AwsConfigProperties properties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Provides SSM client.
+   *
+   * @return created {@link SsmClient} object
+   */
+  public SsmClient get() {
+    log.debug("Initializing AWS SSM client...");
+    var builder = SsmClient.builder();
+    builder.region(Region.of(properties.getRegion()));
+    if (properties.isFipsEnabled()) {
+      builder.httpClient(ApacheHttpClient.builder()
+        .tlsTrustManagersProvider(() -> getTrustManager(properties)).build());
+      builder.fipsEnabled(true);
+    }
+    if (nonNull(properties.getUseIam()) && properties.getUseIam()) {
+      log.debug("Using IAM");
+    } else {
+      builder.credentialsProvider(DefaultCredentialsProvider.create());
+      builder.endpointOverride(endpoint(properties));
+    }
+    return builder.build();
+  }
+
+  private TrustManager[] getTrustManager(AwsConfigProperties properties) {
+    Asserts.notBlank(properties.getTrustStorePath(), "Truststore path must not be blank");
+    try {
+      var trustStore = KeyStore.getInstance(properties.getTrustStoreFileType());
+      try (var trustStoreStream = Files.newInputStream(Path.of(properties.getTrustStorePath()).toAbsolutePath())) {
+        trustStore.load(trustStoreStream, properties.getTrustStorePassword().toCharArray());
+      }
+
+      var trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+      trustManagerFactory.init(trustStore);
+      return trustManagerFactory.getTrustManagers();
+    } catch (Exception e) {
+      throw new SSLInitializationException("Error initializing TrustManager", e);
+    }
+  }
+
+  private static URI endpoint(AwsConfigProperties properties) {
+    var path = properties.getEcsCredentialsPath();
+    if (path == null) {
+      path = System.getenv(ECS_CREDENTIALS_PATH_VAR);
+    }
+    if (path == null) {
+      throw SdkClientException.create("No credentials path was provided and the environment variable "
+        + ECS_CREDENTIALS_PATH_VAR + " is empty");
+    }
+
+    try {
+      return new URI(properties.getEcsCredentialsEndpoint() + path);
+    } catch (URISyntaxException e) {
+      throw SdkClientException.builder().cause(e).build();
+    }
+  }
+
+  private static AwsConfigProperties mapPropertiesToAwsConfigProperties(Properties properties) {
+    return AwsConfigProperties.builder()
+      .useIam(parseBoolean(properties.getProperty(PROP_USE_IAM, DEFAULT_USE_IAM)))
+      .region(properties.getProperty(PROP_REGION))
+      .ecsCredentialsPath(properties.getProperty(PROP_ECS_CREDENTIALS_PATH))
+      .ecsCredentialsEndpoint(properties.getProperty(PROP_ECS_CREDENTIALS_ENDPOINT))
+      .build();
+  }
+}

--- a/folio-secret-store/folio-secret-store-common/src/test/java/org/folio/tools/store/utils/SsmClientProviderTest.java
+++ b/folio-secret-store/folio-secret-store-common/src/test/java/org/folio/tools/store/utils/SsmClientProviderTest.java
@@ -1,0 +1,71 @@
+package org.folio.tools.store.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URISyntaxException;
+import java.security.Security;
+import java.util.Properties;
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
+import org.folio.test.types.UnitTest;
+import org.folio.tools.store.properties.AwsConfigProperties;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+@UnitTest
+class SsmClientProviderTest {
+
+  public static final AwsConfigProperties AWS_CONFIG_PROPERTIES = AwsConfigProperties.builder()
+    .region("us-east-1")
+    .useIam(true)
+    .fipsEnabled(true)
+    .trustStorePath("src/test/resources/certificates/keystore.bcfks")
+    .trustStorePassword("secretpassword")
+    .trustStoreFileType("BCFKS").build();
+
+  static {
+    Security.addProvider(new BouncyCastleFipsProvider());
+  }
+
+  @Test
+  void get_negative_iamDisabled() {
+    var props = AwsConfigProperties.builder().region("us-east-1").useIam(false).build();
+    var ssmClientProvider = new SsmClientProvider(props);
+
+    assertThatThrownBy(ssmClientProvider::get).isInstanceOf(SdkClientException.class);
+  }
+
+  @Test
+  void get_positive() {
+    var ssmClientProvider = new SsmClientProvider(AWS_CONFIG_PROPERTIES);
+    var actual = ssmClientProvider.get();
+    assertThat(actual).isNotNull();
+  }
+
+  @Test
+  void get_positive_propertiesConfiguration() {
+    var properties = new Properties();
+    properties.setProperty("ecsCredentialsPath", "https://example.com/test-credentials-path");
+    properties.setProperty("ecsCredentialsEndpoint", "https://example.com/test-credentials");
+    properties.setProperty("region", "us-east-1");
+    properties.setProperty("useIAM", "false");
+
+    var ssmClientProvider = new SsmClientProvider(properties);
+    var actual = ssmClientProvider.get();
+    assertThat(actual).isNotNull();
+  }
+
+  @Test
+  void get_negative_invalidEcsCredentialsEndpoint() {
+    var properties = new Properties();
+    properties.setProperty("ecsCredentialsPath", "/test-credentials");
+    properties.setProperty("ecsCredentialsEndpoint", "https://example.com/q/h?s=^IXIC");
+    properties.setProperty("region", "us-east-1");
+    properties.setProperty("useIAM", "false");
+
+    var ssmClientProvider = new SsmClientProvider(properties);
+    assertThatThrownBy(ssmClientProvider::get)
+      .isInstanceOf(SdkClientException.class)
+      .hasCauseInstanceOf(URISyntaxException.class);
+  }
+}


### PR DESCRIPTION
### Purpose
Refactor `AwsStore` to not reuse existing ssm client, but use a new one for every call

### Approach
- Refactor `AwsStore` to not reuse existing ssm client, but use a new one for every call
- Update unit tests

### TODOs and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
