### PR TITLE
log failed Kong service deletion

### DIFF
--- a/folio-integration-kong/src/main/java/org/folio/tools/kong/service/KongGatewayService.java
+++ b/folio-integration-kong/src/main/java/org/folio/tools/kong/service/KongGatewayService.java
@@ -119,6 +119,7 @@ public class KongGatewayService {
     try {
       kongAdminClient.deleteService(serviceNameOrId);
     } catch (Exception e) {
+      log.warn("Failed to delete Kong service: {}", serviceNameOrId, e);
       var parameters = List.of(new Parameter().key("cause").value(e.getMessage()));
       throw new KongIntegrationException("Failed to delete Kong service: " + serviceNameOrId, parameters);
     }


### PR DESCRIPTION
### Purpose
The error while Kong service deletion occurs sometimes. 

### Approach
 - add extra login to catch the root cause of error
