### PR TITLE
MGRAPPS-23 Add extension field to the ModuleDescriptor

### DIFF
--- a/folio-backend-common/src/main/java/org/folio/common/domain/model/AnyDescriptor.java
+++ b/folio-backend-common/src/main/java/org/folio/common/domain/model/AnyDescriptor.java
@@ -1,0 +1,25 @@
+package org.folio.common.domain.model;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A way to map arbitrary Json. Used for Docker arguments etc.
+ */
+public class AnyDescriptor {
+
+  private final Map<String, Object> properties = new LinkedHashMap<>();
+
+  @JsonAnyGetter
+  public Map<String, Object> properties() {
+    return properties;
+  }
+
+  @JsonAnySetter
+  public AnyDescriptor set(String fieldName, Object value) {
+    this.properties.put(fieldName, value);
+    return this;
+  }
+}

--- a/folio-backend-common/src/main/java/org/folio/common/domain/model/ModuleDescriptor.java
+++ b/folio-backend-common/src/main/java/org/folio/common/domain/model/ModuleDescriptor.java
@@ -17,10 +17,14 @@ public class ModuleDescriptor {
   private List<RoutingEntry> filters;
   private List<Permission> permissionSets;
   private List<EnvEntry> env;
-  private Object metadata;
   private UiModuleDescriptor uiDescriptor;
   private LaunchDescriptor launchDescriptor;
+
+  @Deprecated
   private UserDescriptor user;
+
+  private AnyDescriptor metadata;
+  private AnyDescriptor extensions;
 
   /**
    * Sets id field and returns {@link ModuleDescriptor}.
@@ -227,16 +231,6 @@ public class ModuleDescriptor {
   }
 
   /**
-   * Sets metadata field and returns {@link ModuleDescriptor}.
-   *
-   * @return modified {@link ModuleDescriptor} value
-   */
-  public ModuleDescriptor metadata(Object metadata) {
-    this.metadata = metadata;
-    return this;
-  }
-
-  /**
    * Sets uiDescriptor field and returns {@link ModuleDescriptor}.
    *
    * @return modified {@link ModuleDescriptor} value
@@ -261,8 +255,29 @@ public class ModuleDescriptor {
    *
    * @return modified {@link ModuleDescriptor} value
    */
+  @Deprecated
   public ModuleDescriptor user(UserDescriptor user) {
     this.user = user;
+    return this;
+  }
+
+  /**
+   * Sets metadata field and returns {@link ModuleDescriptor}.
+   *
+   * @return modified {@link ModuleDescriptor} value
+   */
+  public ModuleDescriptor metadata(AnyDescriptor metadata) {
+    this.metadata = metadata;
+    return this;
+  }
+
+  /**
+   * Sets extensions for {@link ModuleDescriptor} and returns {@link ModuleDescriptor}.
+   *
+   * @return this {@link ModuleDescriptor} with new extensions value
+   */
+  public ModuleDescriptor extensions(AnyDescriptor extensions) {
+    this.extensions = extensions;
     return this;
   }
 }

--- a/folio-security/src/test/resources/json/keycloak/client.json
+++ b/folio-security/src/test/resources/json/keycloak/client.json
@@ -8,7 +8,7 @@
   "authorizationServicesEnabled": true,
   "publicClient": false,
   "attributes": {
-    "descriptor_hash": "465493583"
+    "descriptor_hash": "1694317664"
   },
   "authorizationSettings": {
     "allowRemoteResourceManagement": true,


### PR DESCRIPTION
### Purpose
Adds an extension field to the ModuleDescriptor

### Approach
- Add `extension` field to the ModuleDescriptor

### TODOs and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
