### PR TITLE
APPPOCTOOL-34: Cleanup testcontainers dependencies

### DIFF
--- a/folio-security/pom.xml
+++ b/folio-security/pom.xml
@@ -123,11 +123,13 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -88,23 +88,10 @@
       <!-- Test dependencies -->
       <dependency>
         <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers</artifactId>
+        <artifactId>testcontainers-bom</artifactId>
         <version>${testcontainer.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>postgresql</artifactId>
-        <version>${testcontainer.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>kafka</artifactId>
-        <version>${testcontainer.version}</version>
-        <scope>test</scope>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
In folio-security add test scope to testcontainers dependencies.

In dependencyManagement use testcontainers-bom.

### Purpose
Remove testcontainers dependency from folio-security runtime.
Reduce testcontainer dependency entries in dependencyManagement.

### Approach
Add test scope to testcontainers dependencies in folio-security pom.xml
Replace individual testcontainer dependencies entries by testcontainers-bom in dependencyManagement.