### PR TITLE
APPPOCTOOL-52: Log VaultExeption stacktrace, NotFoundException wrap

### DIFF
--- a/folio-secret-store/folio-secret-store-common/src/main/java/org/folio/tools/store/exception/UncheckedVaultException.java
+++ b/folio-secret-store/folio-secret-store-common/src/main/java/org/folio/tools/store/exception/UncheckedVaultException.java
@@ -1,0 +1,18 @@
+package org.folio.tools.store.exception;
+
+import com.bettercloud.vault.VaultException;
+import java.io.Serial;
+
+public class UncheckedVaultException extends RuntimeException {
+
+  @Serial
+  private static final long serialVersionUID = 28912662L;
+
+  public UncheckedVaultException(String msg, VaultException e) {
+    super(msg, e);
+  }
+
+  public UncheckedVaultException(VaultException e) {
+    super(e);
+  }
+}

--- a/folio-secret-store/folio-secret-store-common/src/main/java/org/folio/tools/store/impl/VaultStore.java
+++ b/folio-secret-store/folio-secret-store-common/src/main/java/org/folio/tools/store/impl/VaultStore.java
@@ -17,6 +17,7 @@ import java.util.Properties;
 import lombok.extern.log4j.Log4j2;
 import org.folio.tools.store.SecureStore;
 import org.folio.tools.store.exception.NotFoundException;
+import org.folio.tools.store.exception.UncheckedVaultException;
 import org.folio.tools.store.properties.VaultConfigProperties;
 
 @Log4j2
@@ -133,7 +134,7 @@ public final class VaultStore implements SecureStore {
       }
       return ret;
     } catch (VaultException e) {
-      throw new NotFoundException(e);
+      throw new UncheckedVaultException(e);
     }
   }
 
@@ -143,7 +144,7 @@ public final class VaultStore implements SecureStore {
       var secretPath = addRootPath(path);
       mergeSecrets(secretPath, secretName, value);
     } catch (VaultException e) {
-      throw new RuntimeException("Failed to save secret for " + secretName, e);
+      throw new UncheckedVaultException("Failed to save secret for " + secretName, e);
     }
   }
 

--- a/folio-security/src/main/java/org/folio/security/integration/keycloak/configuration/KeycloakDataImportConfiguration.java
+++ b/folio-security/src/main/java/org/folio/security/integration/keycloak/configuration/KeycloakDataImportConfiguration.java
@@ -58,10 +58,12 @@ public class KeycloakDataImportConfiguration {
     var admin = properties.getAdmin();
     String clientId = admin.getClientId();
     String secret = null;
+    var key = KeycloakSecretUtils.globalStoreKey(clientId);
     try {
-      secret = secureStore.get(KeycloakSecretUtils.globalStoreKey(clientId));
+      secret = secureStore.get(key);
     } catch (NotFoundException e) {
-      log.warn("Secret for 'admin' client is not defined in the secret store: clientId = {}", clientId);
+      log.warn("Secret for key '{}' for 'admin' client is not defined in the secret store: clientId = {}",
+          key, clientId);
     }
     return secret;
   }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/APPPOCTOOL-52

## Purpose
Log VaultsException error message and stacktrace.

## Approach
Wrap checked VaultException into UncheckedVaultException,
no longer wrap it into NotFoundException.

## Learning
Carefully choose how to wrap a checked exception.

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.