### PR TITLE
APPPOCTOOL-40 Integrate Internal Route Discovery into Sidecar with Dynamic Routing Switch, Replacing Kong

### DIFF
--- a/folio-integration-kong/src/main/java/org/folio/tools/kong/service/KongGatewayService.java
+++ b/folio-integration-kong/src/main/java/org/folio/tools/kong/service/KongGatewayService.java
@@ -206,7 +206,7 @@ public class KongGatewayService {
 
   private List<Pair<Route, RoutingEntry>> prepareRoutes(InterfaceDescriptor desc, String moduleId) {
     var interfaceId = desc.getId() + "-" + desc.getVersion();
-    if (desc.isSystem() && !desc.isTimer()) {
+    if (desc.isSystem()) {
       log.debug("System interface is ignored: moduleId={}, interfaceId={}]", moduleId, interfaceId);
       return emptyList();
     }

--- a/folio-integration-kong/src/test/java/org/folio/tools/kong/service/KongGatewayServiceTest.java
+++ b/folio-integration-kong/src/test/java/org/folio/tools/kong/service/KongGatewayServiceTest.java
@@ -1,56 +1,40 @@
 package org.folio.tools.kong.service;
 
+import feign.FeignException.InternalServerError;
+import feign.FeignException.NotFound;
 import static feign.Request.HttpMethod.GET;
 import static feign.Request.HttpMethod.PUT;
 import static feign.Request.create;
+import feign.RequestTemplate;
 import static java.lang.String.format;
 import static java.lang.String.join;
+import java.util.ArrayList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static java.util.stream.Collectors.joining;
-import static org.apache.commons.codec.digest.DigestUtils.sha1Hex;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.folio.common.domain.model.InterfaceDescriptor.SYSTEM_INTERFACE_TYPE;
-import static org.folio.common.domain.model.InterfaceDescriptor.TIMER_INTERFACE;
-import static org.folio.common.utils.OkapiHeaders.MODULE_ID;
-import static org.folio.common.utils.OkapiHeaders.TENANT;
-import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.kongService;
-import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.mdWithMultipleInterface1;
-import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.mdWithMultipleInterface2;
-import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.mdWithTimerInterface;
-import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.moduleDescriptor;
-import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.multipleTypeHeaders;
-import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.route;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-
-import feign.FeignException.InternalServerError;
-import feign.FeignException.NotFound;
-import feign.RequestTemplate;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import static java.util.stream.Collectors.joining;
 import java.util.stream.Stream;
+import static org.apache.commons.codec.digest.DigestUtils.sha1Hex;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.folio.common.domain.model.InterfaceDescriptor;
+import static org.folio.common.domain.model.InterfaceDescriptor.SYSTEM_INTERFACE_TYPE;
+import static org.folio.common.domain.model.InterfaceDescriptor.TIMER_INTERFACE;
 import org.folio.common.domain.model.ModuleDescriptor;
 import org.folio.common.domain.model.RoutingEntry;
 import org.folio.common.domain.model.error.Parameter;
+import static org.folio.common.utils.OkapiHeaders.MODULE_ID;
+import static org.folio.common.utils.OkapiHeaders.TENANT;
+import static org.folio.common.utils.UuidUtils.randomId;
 import org.folio.test.types.UnitTest;
 import org.folio.tools.kong.client.KongAdminClient;
 import org.folio.tools.kong.client.KongAdminClient.KongResultList;
@@ -58,6 +42,13 @@ import org.folio.tools.kong.exception.KongIntegrationException;
 import org.folio.tools.kong.model.Identifier;
 import org.folio.tools.kong.model.Route;
 import org.folio.tools.kong.model.Service;
+import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.kongService;
+import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.mdWithMultipleInterface1;
+import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.mdWithMultipleInterface2;
+import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.mdWithTimerInterface;
+import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.moduleDescriptor;
+import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.multipleTypeHeaders;
+import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.route;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -66,9 +57,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.platform.commons.util.StringUtils;
 import org.mockito.ArgumentCaptor;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
@@ -76,7 +76,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class KongGatewayServiceTest {
 
   private static final String MOD_ID = "test-module-0.0.1";
-  private static final String SERVICE_ID = UUID.randomUUID().toString();
+  private static final String SERVICE_ID = randomId();
   private static final String SERVICE_URL = "https://mod-foo:443";
   private static final String ROUTE_TAGS = MOD_ID;
 
@@ -135,22 +135,20 @@ class KongGatewayServiceTest {
     }
 
     @Test
-    void positive_timerInterface() {
+    void positive_timerInterfaceIgnored() {
       var serviceId = UUID.randomUUID().toString();
       when(kongAdminClient.getService(MOD_ID)).thenReturn(new Service().id(serviceId).name(MOD_ID));
       when(kongAdminClient.upsertRoute(eq(serviceId), anyString(), routeCaptor.capture())).then(i -> i.getArgument(2));
 
       kongGatewayService.addRoutes(singletonList(mdWithTimerInterface()));
 
-      assertThat(routeCaptor.getAllValues()).hasSize(7).isEqualTo(List.of(
+      assertThat(routeCaptor.getAllValues()).hasSize(5).isEqualTo(List.of(
         route(List.of("GET"), "^/entities/([^/]+)$", "test1-2.0"),
         route(List.of("PUT"), "^/entities/([^/]+)/sub-entities$", "test1-2.0"),
         route(List.of("GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "TRACE"),
           "^/entities/sub-entities(.*)$", 0, "test1-2.0", MOD_ID),
         route(List.of("PUT"), "/tests/1", 1, "test1-2.0", MOD_ID),
-        route(List.of("GET"), "/test2-entities", 1, "test2-1.0", MOD_ID),
-        route(List.of("POST"), "/test/timer1", 1, "_timer-1.0", MOD_ID),
-        route(List.of("POST"), "/test/timer2", 1, "_timer-1.0", MOD_ID)));
+        route(List.of("GET"), "/test2-entities", 1, "test2-1.0", MOD_ID)));
     }
 
     @Test

--- a/folio-integration-kong/src/test/java/org/folio/tools/kong/service/KongGatewayServiceTest.java
+++ b/folio-integration-kong/src/test/java/org/folio/tools/kong/service/KongGatewayServiceTest.java
@@ -1,47 +1,23 @@
 package org.folio.tools.kong.service;
 
-import feign.FeignException.InternalServerError;
-import feign.FeignException.NotFound;
 import static feign.Request.HttpMethod.GET;
 import static feign.Request.HttpMethod.PUT;
 import static feign.Request.create;
-import feign.RequestTemplate;
 import static java.lang.String.format;
 import static java.lang.String.join;
-import java.util.ArrayList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 import static java.util.stream.Collectors.joining;
-import java.util.stream.Stream;
 import static org.apache.commons.codec.digest.DigestUtils.sha1Hex;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.config.Configurator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import org.folio.common.domain.model.InterfaceDescriptor;
 import static org.folio.common.domain.model.InterfaceDescriptor.SYSTEM_INTERFACE_TYPE;
 import static org.folio.common.domain.model.InterfaceDescriptor.TIMER_INTERFACE;
-import org.folio.common.domain.model.ModuleDescriptor;
-import org.folio.common.domain.model.RoutingEntry;
-import org.folio.common.domain.model.error.Parameter;
 import static org.folio.common.utils.OkapiHeaders.MODULE_ID;
 import static org.folio.common.utils.OkapiHeaders.TENANT;
 import static org.folio.common.utils.UuidUtils.randomId;
-import org.folio.test.types.UnitTest;
-import org.folio.tools.kong.client.KongAdminClient;
-import org.folio.tools.kong.client.KongAdminClient.KongResultList;
-import org.folio.tools.kong.exception.KongIntegrationException;
-import org.folio.tools.kong.model.Identifier;
-import org.folio.tools.kong.model.Route;
-import org.folio.tools.kong.model.Service;
 import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.kongService;
 import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.mdWithMultipleInterface1;
 import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.mdWithMultipleInterface2;
@@ -49,6 +25,40 @@ import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.mdW
 import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.moduleDescriptor;
 import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.multipleTypeHeaders;
 import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.route;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import feign.FeignException.InternalServerError;
+import feign.FeignException.NotFound;
+import feign.RequestTemplate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.folio.common.domain.model.InterfaceDescriptor;
+import org.folio.common.domain.model.ModuleDescriptor;
+import org.folio.common.domain.model.RoutingEntry;
+import org.folio.common.domain.model.error.Parameter;
+import org.folio.test.types.UnitTest;
+import org.folio.tools.kong.client.KongAdminClient;
+import org.folio.tools.kong.client.KongAdminClient.KongResultList;
+import org.folio.tools.kong.exception.KongIntegrationException;
+import org.folio.tools.kong.model.Identifier;
+import org.folio.tools.kong.model.Route;
+import org.folio.tools.kong.model.Service;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -57,18 +67,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.platform.commons.util.StringUtils;
 import org.mockito.ArgumentCaptor;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
@@ -445,7 +446,7 @@ class KongGatewayServiceTest {
       var cause = new RuntimeException("Test");
       when(kongAdminClient.getServiceRoutes(MOD_ID, null)).thenThrow(cause);
       assertThatThrownBy(() -> kongGatewayService.deleteServiceRoutes(MOD_ID)).isInstanceOf(
-        KongIntegrationException.class).hasCause(cause)
+          KongIntegrationException.class).hasCause(cause)
         .hasMessage("Failed to delete all routes for service " + MOD_ID);
     }
   }


### PR DESCRIPTION
## Purpose
Kong is no longer responsible for resolving internal system routes (e.g., timer URLs). The internal routing is now fully managed by the Sidecar. Remove route creation in Kong for timer interfaces

US: [APPPOCTOOL-40](https://folio-org.atlassian.net/browse/APPPOCTOOL-40)

## Approach
* Remove route creation in Kong for timer interfaces. KongGatewayService::prepareRoutes - remove condition for timers
* Update tests

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
