### PR TITLE
APPPOCTOOL-53: Upgrade commons-io from 2.11.0 to 2.18.0, CVE-2024-47554

### DIFF
--- a/folio-integration-kong/pom.xml
+++ b/folio-integration-kong/pom.xml
@@ -12,6 +12,9 @@
 
   <properties>
     <spring-cloud-starter-openfeign.version>4.2.0</spring-cloud-starter-openfeign.version>
+    <!-- remove commons-io dependency when spring-cloud-starter-openfeign ships with a
+         non-vulnerable commons-io version (>= 2.14.0), CVE-2024-47554 -->
+    <commons-io.version>2.18.0</commons-io.version>
     <commons-codec.version>1.18.0</commons-codec.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>
 
@@ -40,6 +43,14 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-openfeign</artifactId>
       <version>${spring-cloud-starter-openfeign.version}</version>
+    </dependency>
+
+    <!-- remove commons-io dependency when spring-cloud-starter-openfeign ships with a
+         non-vulnerable commons-io version (>= 2.14.0), CVE-2024-47554 -->
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>${commons-io.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
https://lists.apache.org/thread/6ozr91rr9cj5lm0zyhv30bsp317hk5z1 :

> Uncontrolled Resource Consumption vulnerability in Apache Commons IO.
>
> The org.apache.commons.io.input.XmlStreamReader class may excessively consume CPU resources when processing maliciously crafted input.
>
> This issue affects Apache Commons IO: from 2.0 before 2.14.0.
>
> Users are recommended to upgrade to version 2.14.0 or later, which fixes the issue.

## Purpose
Fix vulnerability in dependency commons-io.

## Approach
Bump minor version of commons-io.

## TODOS and Open Questions
- [x] Check logging

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.