### PR TITLE
MGRENTITLE-113 Validate semver when getting name or version from artifact id

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,3 @@
 ## Version `v3.1.0` (in progress)
 ### Changes:
-* example: Fixed issue with login operation (APPPOCTOOL-1)
+* Validate semver when getting name or version from artifact id (MGRENTITLE-113)

--- a/folio-backend-common/src/main/java/org/folio/common/utils/SemverUtils.java
+++ b/folio-backend-common/src/main/java/org/folio/common/utils/SemverUtils.java
@@ -1,8 +1,6 @@
 package org.folio.common.utils;
 
 import static org.apache.commons.lang3.RegExUtils.removeAll;
-import static org.apache.commons.lang3.StringUtils.chop;
-import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.removeStart;
 import static org.folio.common.utils.CollectionUtils.toStream;
@@ -17,12 +15,11 @@ import org.semver4j.Semver;
 public class SemverUtils {
 
   private static final Pattern VERSION_PATTERN = Pattern.compile(
-    "(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)"
+    "-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)"
       + "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)" //NOSONAR
       + "(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?" //NOSONAR
       + "(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$");
   private static final String VERSION_DELIMITER = "-";
-  private static final String ERROR_MSG = "Source cannot be blank";
 
   /**
    * Returns application/module version from application/module id.
@@ -31,10 +28,8 @@ public class SemverUtils {
    * @return application/module's version
    */
   public static String getVersion(String sourceId) {
-    if (isBlank(sourceId)) {
-      throw new IllegalArgumentException(ERROR_MSG);
-    }
-    return removeStart(sourceId, getName(sourceId) + VERSION_DELIMITER);
+    var name = getName(sourceId);
+    return removeStart(sourceId, name + VERSION_DELIMITER);
   }
 
   /**
@@ -45,9 +40,16 @@ public class SemverUtils {
    */
   public static String getName(String sourceId) {
     if (isEmpty(sourceId)) {
-      throw new IllegalArgumentException(ERROR_MSG);
+      throw new IllegalArgumentException("Source cannot be blank");
     }
-    return chop(removeAll(sourceId, VERSION_PATTERN));
+
+    var name = removeAll(sourceId, VERSION_PATTERN);
+    var version = removeStart(sourceId, name + VERSION_DELIMITER);
+    if (!Semver.isValid(version)) {
+      throw new IllegalArgumentException("Invalid semantic version: source = " + sourceId);
+    }
+
+    return name;
   }
 
   /**


### PR DESCRIPTION
### **Purpose**
When extracting name or version part from artifact id, validate that the given artifact contains correct semantic version and raise an exception if it doesn't
US: [MGRENTITLE-113](https://folio-org.atlassian.net/browse/MGRENTITLE-113)

### **Approach**
* validate that semantic version is correct when extracting name or version part from artifact id ( `SemverUtils.getVersion()`, `SemverUtils.getName()` methods )

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
