### PR TITLE
APPPOCTOOL-56: TESTCONTAINERS_POSTGRES_IMAGE; PostgreSQL 16

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,3 +2,4 @@
 ### Changes:
 * Validate semver when getting name or version from artifact id (MGRENTITLE-113)
 * Replace confluentinc/cp-kafka with apache/kafka-native:3.8.0 ((APPPOCTOOL-55)[https://folio-org.atlassian.net/browse/APPPOCTOOL-55])
+* TESTCONTAINERS\_POSTGRES\_IMAGE; PostgreSQL 16 ((APPPOCTOOL-56)[https://folio-org.atlassian.net/browse/APPPOCTOOL-56])

--- a/folio-backend-testing/pom.xml
+++ b/folio-backend-testing/pom.xml
@@ -116,6 +116,11 @@
       <scope>compile</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/PostgresContainerExtension.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/PostgresContainerExtension.java
@@ -1,5 +1,6 @@
 package org.folio.test.extensions.impl;
 
+import java.util.Map;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -7,10 +8,12 @@ import org.testcontainers.containers.PostgreSQLContainer;
 
 public class PostgresContainerExtension implements BeforeAllCallback, AfterAllCallback {
 
+  private static final String DEFAULT_IMAGE_NAME = "postgres:16-alpine";
+  private static final String IMAGE_NAME = getImageName(System.getenv());
   private static final String SPRING_PROPERTY_NAME = "spring.datasource.url";
 
   @SuppressWarnings("resource")
-  private static final PostgreSQLContainer<?> CONTAINER = new PostgreSQLContainer<>("postgres:12-alpine")
+  private static final PostgreSQLContainer<?> CONTAINER = new PostgreSQLContainer<>(IMAGE_NAME)
     .withDatabaseName("folio_test")
     .withUsername("folio_admin")
     .withPassword("qwerty123");
@@ -27,5 +30,9 @@ public class PostgresContainerExtension implements BeforeAllCallback, AfterAllCa
   @Override
   public void afterAll(ExtensionContext context) {
     System.clearProperty(SPRING_PROPERTY_NAME);
+  }
+
+  static String getImageName(Map<String, String> env) {
+    return env.getOrDefault("TESTCONTAINERS_POSTGRES_IMAGE", DEFAULT_IMAGE_NAME);
   }
 }

--- a/folio-backend-testing/src/test/java/org/folio/test/extensions/EnablePostgresTest.java
+++ b/folio-backend-testing/src/test/java/org/folio/test/extensions/EnablePostgresTest.java
@@ -1,0 +1,24 @@
+package org.folio.test.extensions;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import lombok.SneakyThrows;
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+@EnablePostgres
+class EnablePostgresTest {
+
+  @Test
+  @SneakyThrows
+  void test() {
+    var jdbcUrl = System.getProperty("spring.datasource.url");
+    try (Connection connection = DriverManager.getConnection(jdbcUrl, "folio_admin", "qwerty123")) {
+      assertThat(connection.getMetaData().getDatabaseMajorVersion(), is(16));
+    }
+  }
+}

--- a/folio-backend-testing/src/test/java/org/folio/test/extensions/impl/PostgresContainerExtensionTest.java
+++ b/folio-backend-testing/src/test/java/org/folio/test/extensions/impl/PostgresContainerExtensionTest.java
@@ -1,0 +1,25 @@
+package org.folio.test.extensions.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Map;
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class PostgresContainerExtensionTest {
+
+  @Test
+  void defaultName() {
+    assertThat(PostgresContainerExtension.getImageName(Map.of()), is("postgres:16-alpine"));
+  }
+
+  @Test
+  void envName() {
+    var env = Map.of("FOO", "BAR",
+        "TESTCONTAINERS_POSTGRES_IMAGE", "postgres:17-bookworm",
+        "BAZ", "FOO");
+    assertThat(PostgresContainerExtension.getImageName(env), is("postgres:17-bookworm"));
+  }
+}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/APPPOCTOOL-56

### **Purpose**
Implement
* https://folio-org.atlassian.net/wiki/spaces/TC/pages/5057487/DR-000037+-+TESTCONTAINERS_POSTGRES_IMAGE
* https://folio-org.atlassian.net/wiki/spaces/TC/pages/5057452/DR-000038+-+PostgreSQL+Upgrade+to+16

### **Approach**
Use TESTCONTAINERS_POSTGRES_IMAGE env var if available.
Switch default postgres container image from 12 to 16.

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- n/a **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- n/a **New Properties / Environment Variables** — Updated README.md if new configs were added.
- n/a **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
