### PR TITLE
fix: `collection.post` is DATA not PROCEDURAL

### DIFF
--- a/folio-permission-utils/src/main/java/org/folio/common/utils/permission/PermissionUtils.java
+++ b/folio-permission-utils/src/main/java/org/folio/common/utils/permission/PermissionUtils.java
@@ -36,7 +36,7 @@ public class PermissionUtils {
     entry(MANAGE, List.of("all", "manage", "allops")));
 
   private static final List<String> DATA_KEYWORD_IDENTIFIERS = List.of("item", "collection", "items");
-  private static final Set<String> DATA_SUFFIXES = Set.of(".item.post");
+  private static final Set<String> DATA_SUFFIXES = Set.of(".item.post", ".collection.post");
   private static final List<String> SETTINGS_KEYWORDS = List.of("module", "settings");
   private static final Collection<String> PROCEDURAL_KEYWORDS = Set.of(
     "post", "download", "export", "assign", "restore", "approve", "reopen", "start", "unopen", "validate",

--- a/folio-permission-utils/src/test/java/org/folio/common/utils/permission/PermissionUtilsTest.java
+++ b/folio-permission-utils/src/test/java/org/folio/common/utils/permission/PermissionUtilsTest.java
@@ -34,6 +34,7 @@ class PermissionUtilsTest {
     "owners_collection.view, Owners Collection, DATA, VIEW",
     "perms.all, Perms, DATA, MANAGE",
     "ui-plugin-find-agreement.search, UI-Plugin-Find-Agreement, DATA, VIEW",
+    "roles.collection.post, Roles Collection, DATA, CREATE",
 
     //matched procedural permissions
     "search_index_inventory_reindex.execute, Search Index Inventory Reindex, PROCEDURAL, EXECUTE",


### PR DESCRIPTION
### **Purpose**
Uncorrect matching was found. We have to fix it. Permissions with the postfix `.collection.post` must be of the Data type of capability.
### **Approach**
 - update match rules
 - add tests

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
