### PR TITLE
KEYCLOAK-56: update Keycloak image version to 26.3.2

### DIFF
--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/KeycloakContainerExtension.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/KeycloakContainerExtension.java
@@ -28,7 +28,7 @@ import org.keycloak.representations.idm.PartialImportRepresentation;
 @Log4j2
 public class KeycloakContainerExtension implements BeforeAllCallback, AfterAllCallback {
 
-  private static final String KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:26.1.0";
+  private static final String KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:26.3.2";
   private static final String REALM_JSON = "json/keycloak/master-realm.json";
   private static final String IMPORTED_CLIENT_ID = "folio-backend-admin-client";
   private static final String IMPORTED_CLIENT_SECRET = "supersecret";


### PR DESCRIPTION
### **Purpose**
Update Keycloak image version to 26.3.2 [KEYCLOAK-56](https://folio-org.atlassian.net/browse/KEYCLOAK-56)

### **Approach**
- update Keycloak image version to 26.3.2 in KeycloakContainerExtension

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
