### PR TITLE
APPOCTOOL-64: add wildcard to route's tenant header regex

### DIFF
--- a/folio-integration-kong/src/main/java/org/folio/tools/kong/model/expression/StringExpressionBuilder.java
+++ b/folio-integration-kong/src/main/java/org/folio/tools/kong/model/expression/StringExpressionBuilder.java
@@ -85,8 +85,13 @@ public class StringExpressionBuilder {
    * @return created {@link RouteExpression} object
    */
   public RouteExpression regexMatching(String regex) {
-    var value = requireNonNull(regex, "StringExpression regex must not be null");
-    return buildRouteExpression(field, REGEX_MATCHING, value);
+    requireNonNull(regex, "StringExpression regex must not be null");
+    return buildRouteExpression(field, REGEX_MATCHING, regex);
+  }
+
+  public RouteExpression headerRegexMatching(String regex) {
+    requireNonNull(regex, "StringExpression regex must not be null");
+    return buildRouteExpressionWithRegex(field, regex);
   }
 
   /**
@@ -102,5 +107,10 @@ public class StringExpressionBuilder {
   private static RouteExpression buildRouteExpression(String key, RouteOperator operator, String value) {
     requireNonNull(value, "StringExpression value must not be null");
     return new RouteExpression(key, operator, "\"" + value + "\"");
+  }
+
+  private static RouteExpression buildRouteExpressionWithRegex(String key, String regex) {
+    requireNonNull(regex, "StringExpression regex must not be null");
+    return new RouteExpression(key, REGEX_MATCHING, "r#" + regex + "#");
   }
 }

--- a/folio-integration-kong/src/test/java/org/folio/tools/kong/service/KongGatewayServiceTest.java
+++ b/folio-integration-kong/src/test/java/org/folio/tools/kong/service/KongGatewayServiceTest.java
@@ -23,7 +23,6 @@ import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.mdW
 import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.mdWithMultipleInterface2;
 import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.mdWithTimerInterface;
 import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.moduleDescriptor;
-import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.multipleTypeHeaders;
 import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.route;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -129,9 +128,9 @@ class KongGatewayServiceTest {
       kongGatewayService.addRoutes(List.of(mdWithMultipleInterface1(), mdWithMultipleInterface2()));
 
       assertThat(routeCaptor.getAllValues()).hasSize(4).isEqualTo(List.of(
-        route(List.of("GET"), "/baz/entities", 1, "baz-multiple-1.0", fooModuleId, multipleTypeHeaders(fooModuleId)),
+        route(List.of("GET"), "/baz/entities", 1, "baz-multiple-1.0", fooModuleId),
         route(List.of("POST"), "/foo/entities", 1, "foo-1.0", fooModuleId),
-        route(List.of("GET"), "/baz/entities", 1, "baz-multiple-1.0", barModuleId, multipleTypeHeaders(barModuleId)),
+        route(List.of("GET"), "/baz/entities", 1, "baz-multiple-1.0", barModuleId),
         route(List.of("POST"), "/bar/entities", 1, "bar-1.0", barModuleId)));
     }
 
@@ -474,7 +473,10 @@ class KongGatewayServiceTest {
       var operator = path.endsWith("$") ? "~" : "==";
       var pathExpression = format("http.path %s \"%s\"", operator, path);
 
-      var expression = Stream.of(pathExpression, getMethodsExpression(methods), getHeadersExpression(headers))
+      var tenantHeaderExpression = "http.headers.x_okapi_tenant ~ r#\".*\"#";
+      var expression = Stream.of(pathExpression, getMethodsExpression(methods), getHeadersExpression(headers),
+          tenantHeaderExpression
+        )
         .filter(StringUtils::isNotBlank)
         .collect(joining(" && ", "(", ")"));
 


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/APPPOCTOOL-64
As we implement the ability to run multiple versions of a given application/modules in a given Folio deployment, we need to make some adjustments to the expressions used by match requests to routes.  Specifically, an expression clause is required to check the x-okapi-tenant header. 

### **Approach**
- change tenant header expression
- fix tests

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
