### PR TITLE
feat(tests): Add Kryo serialization utility for object copying in tests

### DIFF
--- a/folio-backend-testing/pom.xml
+++ b/folio-backend-testing/pom.xml
@@ -18,6 +18,7 @@
     <jjwt.version>0.13.0</jjwt.version>
     <testcontainers-keycloak.version>3.8.0</testcontainers-keycloak.version>
     <keycloak-admin-client.version>26.0.6</keycloak-admin-client.version>
+    <kryo.version>5.6.2</kryo.version>
   </properties>
 
   <dependencies>
@@ -120,6 +121,13 @@
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>kryo</artifactId>
+      <version>${kryo.version}</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
### **Purpose**
Add Kryo serialization utility for object copying in tests. Copy the code from [mod-roles-keycloak](https://github.com/folio-org/mod-roles-keycloak/blob/01dc9f65dbd7e8e698bbbc32412b962d1fcb6710/src/test/java/org/folio/roles/support/TestUtils.java#L51)

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
