### PR TITLE
APPPOCTOOL-64: revert enhancing route handling with module ID

### DIFF
--- a/folio-integration-kong/src/test/java/org/folio/tools/kong/service/KongGatewayServiceTest.java
+++ b/folio-integration-kong/src/test/java/org/folio/tools/kong/service/KongGatewayServiceTest.java
@@ -23,6 +23,7 @@ import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.mdW
 import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.mdWithMultipleInterface2;
 import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.mdWithTimerInterface;
 import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.moduleDescriptor;
+import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.multipleTypeHeaders;
 import static org.folio.tools.kong.service.KongGatewayServiceTest.TestValues.route;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -128,9 +129,9 @@ class KongGatewayServiceTest {
       kongGatewayService.addRoutes(List.of(mdWithMultipleInterface1(), mdWithMultipleInterface2()));
 
       assertThat(routeCaptor.getAllValues()).hasSize(4).isEqualTo(List.of(
-        route(List.of("GET"), "/baz/entities", 1, "baz-multiple-1.0", fooModuleId),
+        route(List.of("GET"), "/baz/entities", 1, "baz-multiple-1.0", fooModuleId, multipleTypeHeaders(fooModuleId)),
         route(List.of("POST"), "/foo/entities", 1, "foo-1.0", fooModuleId),
-        route(List.of("GET"), "/baz/entities", 1, "baz-multiple-1.0", barModuleId),
+        route(List.of("GET"), "/baz/entities", 1, "baz-multiple-1.0", barModuleId, multipleTypeHeaders(barModuleId)),
         route(List.of("POST"), "/bar/entities", 1, "bar-1.0", barModuleId)));
     }
 


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/APPPOCTOOL-64
Module ID Kong routing expression was mistakenly removed from Kong's route expressions.
### **Approach**
- revert routes expressions for x-okapi-module-id

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
