### PR TITLE
MODSIDECAR-148: add support for custom Keycloak base URL for JWKS cert

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * Use SECURE\_STORE\_ENV, not ENV, for secure store key; drop KeycloakSecretUtils ((APPPOCTOOL-63)[https://folio-org.atlassian.net/browse/APPPOCTOOL-63])
 * Add verify dependents module workflow (APPPOCTOOL-70)
 * Implement mTLS Client-Side Authentication for FSSP client (APPPOCTOOL-62)
+* Add support for custom Keycloak base URL for JWKS endpoint ((MODSIDECAR-148)[https://folio-org.atlassian.net/browse/MODSIDECAR-148])
 
 ### Migration:
 * Replace KeycloakSecretUtils with SecureStoreKeyProvider, add `application.secret-store.environment=${SECURE_STORE_ENV:folio}` to application.yaml (for Ramsons and Sunflower: add `application.secret-store.environment=${SECURE_STORE_ENV:${ENV:folio}}` to application.yaml).

--- a/folio-auth-openid/src/test/java/org/folio/jwt/openid/OpenidJwtParserProviderTest.java
+++ b/folio-auth-openid/src/test/java/org/folio/jwt/openid/OpenidJwtParserProviderTest.java
@@ -21,7 +21,7 @@ class OpenidJwtParserProviderTest {
 
   @BeforeEach
   void setUp() {
-    openidJwtParserProvider = new OpenidJwtParserProvider(60, 60);
+    openidJwtParserProvider = new OpenidJwtParserProvider(60, 60, null);
   }
 
   @Test
@@ -99,6 +99,54 @@ class OpenidJwtParserProviderTest {
 
     openidJwtParserProvider.invalidateCache(List.of("other_tenant_id"));
     assertThat(cache).isEmpty();
+  }
+
+  @Test
+  void getParser_positive_withCustomKeycloakBaseUrl() {
+    var customBaseUrl = "http://keycloak-headless:8080";
+    var providerWithCustomUrl = new OpenidJwtParserProvider(60, 60, customBaseUrl);
+
+    var parser = providerWithCustomUrl.getParser(ISSUER_URI);
+    assertThat(parser).isNotNull();
+
+    var cachedParser = providerWithCustomUrl.getParser(ISSUER_URI);
+    assertThat(cachedParser).isEqualTo(parser);
+  }
+
+  @Test
+  void getParser_positive_withCustomKeycloakBaseUrlTrailingSlash() {
+    var customBaseUrl = "http://keycloak-headless:8080/";
+    var providerWithCustomUrl = new OpenidJwtParserProvider(60, 60, customBaseUrl);
+
+    var parser = providerWithCustomUrl.getParser(ISSUER_URI);
+    assertThat(parser).isNotNull();
+  }
+
+  @Test
+  void getParser_positive_withEmptyCustomKeycloakBaseUrl() {
+    var providerWithEmptyUrl = new OpenidJwtParserProvider(60, 60, "");
+
+    var parser = providerWithEmptyUrl.getParser(ISSUER_URI);
+    assertThat(parser).isNotNull();
+  }
+
+  @Test
+  void getParser_positive_withBlankCustomKeycloakBaseUrl() {
+    var providerWithBlankUrl = new OpenidJwtParserProvider(60, 60, "   ");
+
+    var parser = providerWithBlankUrl.getParser(ISSUER_URI);
+    assertThat(parser).isNotNull();
+  }
+
+  @Test
+  void getParser_positive_backwardCompatibility() {
+    var providerWithOldConstructor = new OpenidJwtParserProvider(60, 60);
+
+    var parser = providerWithOldConstructor.getParser(ISSUER_URI);
+    assertThat(parser).isNotNull();
+
+    var cachedParser = providerWithOldConstructor.getParser(ISSUER_URI);
+    assertThat(cachedParser).isEqualTo(parser);
   }
 
   @SuppressWarnings("unchecked")

--- a/folio-security/src/main/java/org/folio/security/integration/keycloak/configuration/KeycloakSecurityConfiguration.java
+++ b/folio-security/src/main/java/org/folio/security/integration/keycloak/configuration/KeycloakSecurityConfiguration.java
@@ -73,7 +73,8 @@ public class KeycloakSecurityConfiguration {
     var jwtCacheConfiguration = properties.getJwtCacheConfiguration();
     return new OpenidJwtParserProvider(
       jwtCacheConfiguration.getJwksRefreshInterval(),
-      jwtCacheConfiguration.getForcedJwksRefreshInterval());
+      jwtCacheConfiguration.getForcedJwksRefreshInterval(),
+      properties.getJwksKeycloakBaseUrl());
   }
 
   @Bean

--- a/folio-security/src/main/java/org/folio/security/integration/keycloak/configuration/properties/KeycloakProperties.java
+++ b/folio-security/src/main/java/org/folio/security/integration/keycloak/configuration/properties/KeycloakProperties.java
@@ -18,6 +18,14 @@ public class KeycloakProperties {
   private String url;
 
   /**
+   * Custom base URL for JWKS endpoint.
+   * If specified, will be used instead of issuer URL from token's iss claim.
+   * Useful for using internal Keycloak interface instead of public one.
+   * Example: <a href="http://keycloak-headless:8080">...</a>
+   */
+  private String jwksKeycloakBaseUrl;
+
+  /**
    * Authentication JWT parser configuration settings.
    */
   private KeycloakJwtCacheProperties jwtCacheConfiguration = new KeycloakJwtCacheProperties();


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODSIDECAR-148

Presently the sidecars obtain the public signing keys from keycloak by forming the URL based on the iss claim in the access token.  However, in some setups it’s desirable to use a different base URL for this.  More specifically in cases where it’s preferable to have the sidecars use an internal interface (e.g. http://keycloak-headless:8080/) instead of the public interface (e.g. https://keycloak-folio-dev.stanford.edu/).

### **Approach**
- add an option to specify Keycloak base URL for JWKS cert retrieval
- add tests
---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
