### PR TITLE
APPPOCTOOL-85: Generalize Kafka consumer tenant filter to support custom event types

### DIFF
--- a/folio-integration-kafka/folio-kafka-common/README.md
+++ b/folio-integration-kafka/folio-kafka-common/README.md
@@ -6,6 +6,7 @@ operation enum used by both Kafka producers and consumers across all FOLIO modul
 ## Table of Contents
 
 - [Event Model](#event-model)
+- [Tenant-Aware Contract](#tenant-aware-contract)
 - [Event Types](#event-types)
 
 ---
@@ -38,6 +39,24 @@ ResourceEvent<Item> event = ResourceEvent.<Item>builder()
     .newValue(item)
     .build();
 ```
+
+---
+
+## Tenant-Aware Contract
+
+### `TenantAwareEvent`
+
+A lightweight interface for event payloads that carry a tenant identifier. Implement it to make a
+custom event type work with the consumer-side tenant filter without depending on `ResourceEvent`.
+
+```java
+public interface TenantAwareEvent {
+    @Nullable String getTenant();
+}
+```
+
+`ResourceEvent<T>` implements this interface out of the box, so no change is required for existing
+listeners that already use `ResourceEvent`.
 
 ---
 

--- a/folio-integration-kafka/folio-kafka-common/src/main/java/org/folio/integration/kafka/model/ResourceEvent.java
+++ b/folio-integration-kafka/folio-kafka-common/src/main/java/org/folio/integration/kafka/model/ResourceEvent.java
@@ -17,7 +17,7 @@ import org.jspecify.annotations.Nullable;
  */
 @Data
 @Builder
-public class ResourceEvent<T> {
+public class ResourceEvent<T> implements TenantAwareEvent {
 
   /**
    * Resource identifier.

--- a/folio-integration-kafka/folio-kafka-common/src/main/java/org/folio/integration/kafka/model/TenantAwareEvent.java
+++ b/folio-integration-kafka/folio-kafka-common/src/main/java/org/folio/integration/kafka/model/TenantAwareEvent.java
@@ -1,0 +1,24 @@
+package org.folio.integration.kafka.model;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Contract for Kafka event payloads that carry a tenant identifier.
+ *
+ * <p>Implement this interface to make a custom event type compatible with
+ * {@link org.folio.integration.kafka.consumer.filter.EnabledTenantMessageFilter}.
+ * {@link ResourceEvent} implements this interface out of the box.
+ */
+public interface TenantAwareEvent {
+
+  /**
+   * Returns the tenant identifier for this event.
+   *
+   * <p>A {@code null} or blank value is treated as absent by
+   * {@link org.folio.integration.kafka.consumer.filter.EnabledTenantMessageFilter}:
+   * the record is accepted without consulting the entitlement service and a warning is logged.
+   *
+   * @return the tenant name, or {@code null} / blank for malformed events
+   */
+  @Nullable String getTenant();
+}

--- a/folio-integration-kafka/folio-kafka-common/src/main/java/org/folio/integration/kafka/model/package-info.java
+++ b/folio-integration-kafka/folio-kafka-common/src/main/java/org/folio/integration/kafka/model/package-info.java
@@ -1,10 +1,16 @@
 /**
  * Domain model classes for Kafka resource events.
  *
- * <p>Contains the generic event envelope ({@link org.folio.integration.kafka.model.ResourceEvent})
- * and the lifecycle operation enumeration
- * ({@link org.folio.integration.kafka.model.ResourceEventType}), shared between Kafka producers
- * and consumers.
+ * <p>Contains the following public types, shared between Kafka producers and consumers:
+ * <ul>
+ *   <li>{@link org.folio.integration.kafka.model.TenantAwareEvent} — contract for event payloads
+ *       that carry a tenant identifier; used as the type bound by the consumer filter;</li>
+ *   <li>{@link org.folio.integration.kafka.model.ResourceEvent} — generic event envelope
+ *       implementing {@code TenantAwareEvent} and carrying metadata and an optional resource
+ *       payload;</li>
+ *   <li>{@link org.folio.integration.kafka.model.ResourceEventType} — lifecycle operation
+ *       enumeration ({@code CREATE}, {@code UPDATE}, {@code DELETE}, {@code DELETE_ALL}).</li>
+ * </ul>
  */
 @NullMarked
 package org.folio.integration.kafka.model;

--- a/folio-integration-kafka/folio-kafka-consumer/README.md
+++ b/folio-integration-kafka/folio-kafka-consumer/README.md
@@ -48,6 +48,7 @@ application:
         items:
           topic-pattern: trillium\..*\.inventory\.items   # regex
           group-id: mod-my-service-items-group
+          concurrency: 3                                  # default: 1
         orders:
           topic-pattern: trillium\..*\.orders
           group-id: mod-my-service-orders-group
@@ -78,7 +79,8 @@ Set `application.kafka.consumer.filtering.tenant-filter.enabled=true` to activat
 
 When enabled, `EnabledTenantMessageFilter` intercepts every incoming record:
 
-1. Extracts the `tenant` field from the `ResourceEvent` payload.
+1. Calls `getTenant()` on the `TenantAwareEvent` payload. If the value is blank or `null`, the
+   record is accepted immediately and a warning is logged — no entitlement check is performed.
 2. Calls the tenant-entitlement service to fetch the set of tenants currently entitled for this
    module (result is cached per poll cycle).
 3. If the entitled set is **non-empty** but does not contain the record's tenant, the
@@ -199,6 +201,7 @@ so a custom `RecordFilterStrategy` bean with that name takes precedence.
 |:----------------------------------------------------------------------------------|:----------|:---------|:--------------------------------------------------------|
 | `application.kafka.consumer.listener.<name>.topic-pattern`                        | `String`  | —        | Regex topic-name pattern for the named listener         |
 | `application.kafka.consumer.listener.<name>.group-id`                             | `String`  | —        | Consumer group ID for the named listener                |
+| `application.kafka.consumer.listener.<name>.concurrency`                          | `Integer` | `1`      | Number of concurrent consumer threads for the listener  |
 | `application.kafka.consumer.filtering.tenant-filter.enabled`                      | `boolean` | `false`  | Activate real tenant-entitlement filtering              |
 | `application.kafka.consumer.filtering.tenant-filter.ignore-empty-batch`           | `boolean` | `true`   | Signal Kafka to skip delivery on empty poll batches     |
 | `application.kafka.consumer.filtering.tenant-filter.tenant-disabled-strategy`     | `String`  | `SKIP`   | Strategy when a record's tenant is not entitled         |

--- a/folio-integration-kafka/folio-kafka-consumer/src/main/java/org/folio/integration/kafka/consumer/configuration/KafkaConsumerProperties.java
+++ b/folio-integration-kafka/folio-kafka-consumer/src/main/java/org/folio/integration/kafka/consumer/configuration/KafkaConsumerProperties.java
@@ -39,5 +39,10 @@ public class KafkaConsumerProperties {
      * Consumer group identifier; overrides the global {@code spring.kafka.consumer.group-id}.
      */
     private String groupId;
+
+    /**
+     * Number of concurrent consumers in service.
+     */
+    private Integer concurrency = 1;
   }
 }

--- a/folio-integration-kafka/folio-kafka-consumer/src/main/java/org/folio/integration/kafka/consumer/filter/EnabledTenantMessageFilter.java
+++ b/folio-integration-kafka/folio-kafka-consumer/src/main/java/org/folio/integration/kafka/consumer/filter/EnabledTenantMessageFilter.java
@@ -9,7 +9,7 @@ import java.util.function.Supplier;
 import lombok.extern.log4j.Log4j2;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.folio.integration.kafka.consumer.filter.te.TenantEntitlementService;
-import org.folio.integration.kafka.model.ResourceEvent;
+import org.folio.integration.kafka.model.TenantAwareEvent;
 import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
 
 /**
@@ -26,10 +26,10 @@ import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
  * </ul>
  *
  * @param <K> the Kafka record key type
- * @param <V> the record value type; must extend {@link ResourceEvent}
+ * @param <V> the record value type; must implement {@link TenantAwareEvent}
  */
 @Log4j2
-public class EnabledTenantMessageFilter<K, V extends ResourceEvent<?>> implements RecordFilterStrategy<K, V> {
+public class EnabledTenantMessageFilter<K, V extends TenantAwareEvent> implements RecordFilterStrategy<K, V> {
 
   private final String moduleId;
   private final TenantEntitlementService tenantEntitlementService;
@@ -69,6 +69,12 @@ public class EnabledTenantMessageFilter<K, V extends ResourceEvent<?>> implement
     var key = consumerRecord.key();
     var value = consumerRecord.value();
     var tenant = value.getTenant();
+
+    if (isBlank(tenant)) {
+      log.warn("Received message with blank tenant: messageKey = {}, tenant = '{}'. Filter won't be applied.",
+        key, tenant);
+      return false;
+    }
 
     log.debug("Filtering message for tenant: messageKey = {}, tenant = {}", key, tenant);
 

--- a/folio-integration-kafka/folio-kafka-consumer/src/test/java/org/folio/integration/kafka/consumer/filter/EnabledTenantMessageFilterTest.java
+++ b/folio-integration-kafka/folio-kafka-consumer/src/test/java/org/folio/integration/kafka/consumer/filter/EnabledTenantMessageFilterTest.java
@@ -155,9 +155,9 @@ class EnabledTenantMessageFilterTest {
     when(tenantEntitlementService.getEnabledTenants()).thenReturn(ENABLED_TENANTS);
 
     TenantAwareEvent customEvent = () -> TENANT;
-    var record = new ConsumerRecord<>("test-topic", 0, 0L, "key-1", customEvent);
+    var rec = new ConsumerRecord<>("test-topic", 0, 0L, "key-1", customEvent);
 
-    assertThat(filter.filter(record)).isFalse();
+    assertThat(filter.filter(rec)).isFalse();
   }
 
   @Test

--- a/folio-integration-kafka/folio-kafka-consumer/src/test/java/org/folio/integration/kafka/consumer/filter/EnabledTenantMessageFilterTest.java
+++ b/folio-integration-kafka/folio-kafka-consumer/src/test/java/org/folio/integration/kafka/consumer/filter/EnabledTenantMessageFilterTest.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.folio.integration.kafka.consumer.filter.te.TenantEntitlementService;
 import org.folio.integration.kafka.model.ResourceEvent;
+import org.folio.integration.kafka.model.TenantAwareEvent;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -134,6 +135,29 @@ class EnabledTenantMessageFilterTest {
     assertThatThrownBy(() -> filter.filter(rec))
       .isInstanceOf(TenantsAreDisabledException.class)
       .hasMessageContaining(MODULE_ID);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = " ")
+  void filter_positive_blankTenant_returnsAccepted(String blankTenant) {
+    var filter = createFilter(false, SKIP, SKIP);
+
+    var result = filter.filter(consumerRecord("key-1", blankTenant));
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void filter_positive_customTenantAwareEvent_enabledTenant_returnsAccepted() {
+    var filter = new EnabledTenantMessageFilter<String, TenantAwareEvent>(
+      MODULE_ID, tenantEntitlementService, false, SKIP, SKIP);
+    when(tenantEntitlementService.getEnabledTenants()).thenReturn(ENABLED_TENANTS);
+
+    TenantAwareEvent customEvent = () -> TENANT;
+    var record = new ConsumerRecord<>("test-topic", 0, 0L, "key-1", customEvent);
+
+    assertThat(filter.filter(record)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
### **Purpose**
Extends the Kafka consumer library to allow tenant-aware filtering for any message type, not just
`ResourceEvent`. Adds per-listener concurrency configuration and a blank-tenant guard in the filter.
US: [APPPOCTOOL-85](https://folio-org.atlassian.net/browse/APPPOCTOOL-85)

### **Approach**
A new `TenantAwareEvent` interface extracts the tenant contract from `ResourceEvent`, allowing
`EnabledTenantMessageFilter` to be parameterized over any custom event type. A blank-tenant guard
is added to the filter to short-circuit entitlement checks for malformed messages, and a
`concurrency` property is introduced to `KafkaListenerProperties` for tuning concurrent consumer
threads per listener.

**Implementation details:**

- Introduced `TenantAwareEvent` marker interface with a single `@Nullable getTenant()` method;
  `ResourceEvent<T>` now implements it, preserving backward compatibility for existing consumers.
- Changed `EnabledTenantMessageFilter<K, V>` type bound from `V extends ResourceEvent<?>` to
  `V extends TenantAwareEvent`, so any custom event class can be filtered without inheriting from
  `ResourceEvent`.
- Added a blank-tenant guard at the start of `EnabledTenantMessageFilter#filter`: if `getTenant()`
  returns `null` or blank the record is accepted immediately and a `WARN` log entry is emitted,
  avoiding an unnecessary entitlement service call.
- Added `concurrency` field (default `1`) to `KafkaListenerProperties`; lets consumers declare the
  number of concurrent threads per listener directly in `application.kafka.consumer.listener.<name>`.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [x] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.