### PR TITLE
APPPOCTOOL-85: Auto-configure tenant entitlement client from okapi.url

### DIFF
--- a/folio-integration-kafka/folio-kafka-consumer/README.md
+++ b/folio-integration-kafka/folio-kafka-consumer/README.md
@@ -98,21 +98,17 @@ When enabled, `EnabledTenantMessageFilter` intercepts every incoming record:
 
 ### Tenant entitlement service
 
-When `tenant-filter.enabled=true`, the application context must expose an
-`HttpServiceProxyFactory` bean configured with the base URL of the tenant-entitlement service.
-The library creates the `TenantEntitlementClient` from it automatically.
+When `tenant-filter.enabled=true`, the library creates and configures the `TenantEntitlementClient`
+automatically. The consuming application only needs to supply the base URL via the `okapi.url`
+property — no manually created beans are required.
 
-```java
-@Bean
-public HttpServiceProxyFactory httpServiceProxyFactory(RestClient.Builder restClientBuilder) {
-    RestClient restClient = restClientBuilder
-        .baseUrl("http://mgr-tenant-entitlements:8080")
-        .build();
-    return HttpServiceProxyFactory
-        .builderFor(RestClientAdapter.create(restClient))
-        .build();
-}
+```yaml
+okapi:
+  url: http://mgr-tenant-entitlements:8080
 ```
+
+If the `loggingInterceptor` bean from `folio-spring-support` is present on the classpath, it is
+picked up automatically and applied to every request made by the entitlement client.
 
 ### Filtering configuration
 

--- a/folio-integration-kafka/folio-kafka-consumer/src/main/java/org/folio/integration/kafka/consumer/configuration/KafkaConsumerFilteringConfiguration.java
+++ b/folio-integration-kafka/folio-kafka-consumer/src/main/java/org/folio/integration/kafka/consumer/configuration/KafkaConsumerFilteringConfiguration.java
@@ -64,6 +64,16 @@ public class KafkaConsumerFilteringConfiguration {
       this.tenantFilter = kafkaProperties.getFiltering().getTenantFilter();
     }
 
+    /**
+     * Rest Client configuration for the tenant entitlement client.
+     *
+     * @param okapiUrl the base URL for the tenant entitlement client, provided via application properties;
+     *                 must not be blank
+     * @param jsonMapper the Jackson JSON mapper to use for message conversion; auto-configured by Spring Boot
+     * @param loggingInterceptor logging interceptor from folio-spring-support, if available;
+     *                           auto-configured by folio-spring-support when the library is on the classpath
+     * @return rest client configurer for kafka-filter-entitlement-client group
+     */
     @Bean
     public RestClientHttpServiceGroupConfigurer tenantEntitlementClientGroupConfigurer(
       @Value("${okapi.url}") @NotBlank String okapiUrl, JsonMapper jsonMapper,
@@ -80,6 +90,7 @@ public class KafkaConsumerFilteringConfiguration {
               .addCustomConverter(new JacksonJsonHttpMessageConverter(jsonMapper))
               .addCustomConverter(new StringHttpMessageConverter()));
 
+        // utilize logging interceptor from folio-spring-support lib, if available
         if (loggingInterceptor != null) {
           builder
             .bufferContent((uri, httpMethod) -> true)

--- a/folio-integration-kafka/folio-kafka-consumer/src/main/java/org/folio/integration/kafka/consumer/configuration/KafkaConsumerFilteringConfiguration.java
+++ b/folio-integration-kafka/folio-kafka-consumer/src/main/java/org/folio/integration/kafka/consumer/configuration/KafkaConsumerFilteringConfiguration.java
@@ -47,9 +47,9 @@ public class KafkaConsumerFilteringConfiguration {
    *
    * <p>Enabled when {@code application.kafka.consumer.filtering.tenant-filter.enabled=true}.
    *
-   * <p><strong>Required bean:</strong> the consuming application must expose an
-   * {@link org.springframework.web.service.invoker.HttpServiceProxyFactory} bean configured
-   * with the base URL of the tenant-entitlement service. Without it, context startup will fail.
+   * <p><strong>Required property:</strong> the consuming application must provide the
+   * {@code okapi.url} property with the base URL of the tenant-entitlement service.
+   * Without it, context startup will fail.
    */
   @Configuration
   @ConditionalOnProperty(value = "application.kafka.consumer.filtering.tenant-filter.enabled", havingValue = "true")

--- a/folio-integration-kafka/folio-kafka-consumer/src/main/java/org/folio/integration/kafka/consumer/configuration/KafkaConsumerFilteringConfiguration.java
+++ b/folio-integration-kafka/folio-kafka-consumer/src/main/java/org/folio/integration/kafka/consumer/configuration/KafkaConsumerFilteringConfiguration.java
@@ -1,5 +1,6 @@
 package org.folio.integration.kafka.consumer.configuration;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.extern.log4j.Log4j2;
 import org.folio.integration.kafka.consumer.configuration.KafkaConsumerFiltering.TenantFilter;
 import org.folio.integration.kafka.consumer.filter.EnabledTenantMessageFilter;
@@ -7,12 +8,20 @@ import org.folio.integration.kafka.consumer.filter.mmd.ModuleMetadata;
 import org.folio.integration.kafka.consumer.filter.te.TenantEntitlementClient;
 import org.folio.integration.kafka.consumer.filter.te.TenantEntitlementService;
 import org.folio.integration.kafka.model.ResourceEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
-import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+import org.springframework.web.client.support.RestClientHttpServiceGroupConfigurer;
+import org.springframework.web.service.registry.ImportHttpServices;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Spring {@link Configuration} that registers the {@code tenantAwareMessageFilter} bean.
@@ -44,6 +53,7 @@ public class KafkaConsumerFilteringConfiguration {
    */
   @Configuration
   @ConditionalOnProperty(value = "application.kafka.consumer.filtering.tenant-filter.enabled", havingValue = "true")
+  @ImportHttpServices(types = TenantEntitlementClient.class, group = "kafka-filter-entitlement-client")
   public static class TenantFilterConfiguration {
 
     private final ModuleMetadata moduleMetadata;
@@ -55,8 +65,29 @@ public class KafkaConsumerFilteringConfiguration {
     }
 
     @Bean
-    public TenantEntitlementClient tenantEntitlementClient(HttpServiceProxyFactory factory) {
-      return factory.createClient(TenantEntitlementClient.class);
+    public RestClientHttpServiceGroupConfigurer tenantEntitlementClientGroupConfigurer(
+      @Value("${okapi.url}") @NotBlank String okapiUrl, JsonMapper jsonMapper,
+      @Qualifier("loggingInterceptor") @Autowired(required = false) ClientHttpRequestInterceptor loggingInterceptor) {
+
+      // the group name should match with the one defined in ImportHttpServices for tenant entitlement client;
+      // the configurer will be applied to all clients in that group (in this case, there's only one client)
+      return groups -> groups.filterByName("kafka-filter-entitlement-client").forEachClient((group, builder) -> {
+
+        builder
+          .baseUrl(okapiUrl) // set base url for the client to a value provided in 'okapi.url' application property
+          .configureMessageConverters(converters ->
+            converters
+              .addCustomConverter(new JacksonJsonHttpMessageConverter(jsonMapper))
+              .addCustomConverter(new StringHttpMessageConverter()));
+
+        if (loggingInterceptor != null) {
+          builder
+            .bufferContent((uri, httpMethod) -> true)
+            .requestInterceptor(loggingInterceptor);
+        }
+
+        builder.build();
+      });
     }
 
     @Bean

--- a/folio-integration-kafka/folio-kafka-consumer/src/main/java/org/folio/integration/kafka/consumer/filter/te/TenantEntitlementClient.java
+++ b/folio-integration-kafka/folio-kafka-consumer/src/main/java/org/folio/integration/kafka/consumer/filter/te/TenantEntitlementClient.java
@@ -11,8 +11,7 @@ import org.springframework.web.service.annotation.HttpExchange;
  * Spring HTTP interface client for the tenant-entitlement service.
  *
  * <p>All requests are sent to the {@code /entitlements} resource path relative to the base URL
- * configured on the {@link org.springframework.web.service.invoker.HttpServiceProxyFactory}
- * used to create this client.
+ * configured via the {@code okapi.url} application property.
  */
 @HttpExchange(url = "entitlements", contentType = APPLICATION_JSON_VALUE)
 public interface TenantEntitlementClient {

--- a/folio-integration-kafka/folio-kafka-consumer/src/test/java/org/folio/integration/kafka/consumer/it/KafkaConsumerFilteringIT.java
+++ b/folio-integration-kafka/folio-kafka-consumer/src/test/java/org/folio/integration/kafka/consumer/it/KafkaConsumerFilteringIT.java
@@ -26,7 +26,6 @@ import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.kafka.autoconfigure.KafkaProperties;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -40,9 +39,7 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.web.client.RestClient;
-import org.springframework.web.client.support.RestClientAdapter;
-import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+import tools.jackson.databind.json.JsonMapper;
 
 @IntegrationTest
 @EnableKafka
@@ -106,13 +103,9 @@ class KafkaConsumerFilteringIT {
   @EnableConfigurationProperties({KafkaProperties.class})
   static class TestConfig {
 
-    @Value("${wm.url}")
-    private String wmUrl;
-
     @Bean
-    HttpServiceProxyFactory httpServiceProxyFactory() {
-      var restClient = RestClient.builder().baseUrl(wmUrl).build();
-      return HttpServiceProxyFactory.builderFor(RestClientAdapter.create(restClient)).build();
+    JsonMapper jsonMapper() {
+      return new JsonMapper();
     }
 
     @Bean

--- a/folio-integration-kafka/folio-kafka-consumer/src/test/resources/wiremock-url.vars
+++ b/folio-integration-kafka/folio-kafka-consumer/src/test/resources/wiremock-url.vars
@@ -1,0 +1,1 @@
+okapi.url


### PR DESCRIPTION
### **Purpose**
Previously, consumers enabling tenant-aware filtering had to manually expose an `HttpServiceProxyFactory` bean to supply the base URL for the tenant-entitlement REST client. This change moves client construction into the library so consumers only need to provide the `okapi.url` property.
US: [APPPOCTOOL-85](https://folio-org.atlassian.net/browse/APPPOCTOOL-85)

### **Approach**
`TenantFilterConfiguration` is annotated with `@ImportHttpServices` to declare `TenantEntitlementClient` as a Spring HTTP service in a named group (`kafka-filter-entitlement-client`). The library contributes a `RestClientHttpServiceGroupConfigurer` bean that wires the `okapi.url` property as the base URL and registers custom Jackson and `String` message converters. An optional `loggingInterceptor` bean from `folio-spring-support` is detected at startup and applied to every outgoing request when present.

**Implementation details:**

- Annotated `TenantFilterConfiguration` with `@ImportHttpServices` to register `TenantEntitlementClient` in the `kafka-filter-entitlement-client` HTTP service group; consumers no longer need to provide an `HttpServiceProxyFactory` bean.
- Introduced `tenantEntitlementClientGroupConfigurer` bean that reads the base URL from the `${okapi.url}` property and configures `JacksonJsonHttpMessageConverter` and `StringHttpMessageConverter` on the REST client.
- Added optional auto-integration with `loggingInterceptor` from `folio-spring-support`: if the bean is present, content buffering is enabled and the interceptor is attached to the client automatically.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [x] **Breaking Changes (if any)** — Consumers must remove any `HttpServiceProxyFactory` bean and
  provide `okapi.url` instead.
- [x] **New Properties / Environment Variables** — `okapi.url` is now required when
  `tenant-filter.enabled=true`; README updated.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
