### PR TITLE
MODUSERSKC-154: Add Jackson deserialization support to ResourceEvent alongside builder

### DIFF
--- a/folio-integration-kafka/folio-kafka-common/src/main/java/org/folio/integration/kafka/model/ResourceEvent.java
+++ b/folio-integration-kafka/folio-kafka-common/src/main/java/org/folio/integration/kafka/model/ResourceEvent.java
@@ -1,7 +1,9 @@
 package org.folio.integration.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -15,6 +17,8 @@ import org.jspecify.annotations.Nullable;
  * @param <T> the domain resource type carried in this event
  */
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class ResourceEvent<T> implements TenantAwareEvent {
 
   /**
@@ -50,34 +54,4 @@ public class ResourceEvent<T> implements TenantAwareEvent {
   @Nullable
   @JsonProperty("old")
   private T oldValue;
-
-  public ResourceEvent<T> id(String id) {
-    this.id = id;
-    return this;
-  }
-
-  public ResourceEvent<T> type(ResourceEventType type) {
-    this.type = type;
-    return this;
-  }
-
-  public ResourceEvent<T> tenant(String tenant) {
-    this.tenant = tenant;
-    return this;
-  }
-
-  public ResourceEvent<T> resourceName(String resourceName) {
-    this.resourceName = resourceName;
-    return this;
-  }
-
-  public ResourceEvent<T> newValue(T newValue) {
-    this.newValue = newValue;
-    return this;
-  }
-
-  public ResourceEvent<T> oldValue(T oldValue) {
-    this.oldValue = oldValue;
-    return this;
-  }
 }

--- a/folio-integration-kafka/folio-kafka-common/src/main/java/org/folio/integration/kafka/model/ResourceEvent.java
+++ b/folio-integration-kafka/folio-kafka-common/src/main/java/org/folio/integration/kafka/model/ResourceEvent.java
@@ -2,6 +2,7 @@ package org.folio.integration.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.jspecify.annotations.Nullable;
@@ -19,6 +20,7 @@ import org.jspecify.annotations.Nullable;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder(builderMethodName = "baseBuilder")
 public class ResourceEvent<T> implements TenantAwareEvent {
 
   /**

--- a/folio-integration-kafka/folio-kafka-common/src/main/java/org/folio/integration/kafka/model/ResourceEvent.java
+++ b/folio-integration-kafka/folio-kafka-common/src/main/java/org/folio/integration/kafka/model/ResourceEvent.java
@@ -1,7 +1,6 @@
 package org.folio.integration.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
 import lombok.Data;
 import org.jspecify.annotations.Nullable;
 
@@ -16,7 +15,6 @@ import org.jspecify.annotations.Nullable;
  * @param <T> the domain resource type carried in this event
  */
 @Data
-@Builder
 public class ResourceEvent<T> implements TenantAwareEvent {
 
   /**
@@ -52,4 +50,34 @@ public class ResourceEvent<T> implements TenantAwareEvent {
   @Nullable
   @JsonProperty("old")
   private T oldValue;
+
+  public ResourceEvent<T> id(String id) {
+    this.id = id;
+    return this;
+  }
+
+  public ResourceEvent<T> type(ResourceEventType type) {
+    this.type = type;
+    return this;
+  }
+
+  public ResourceEvent<T> tenant(String tenant) {
+    this.tenant = tenant;
+    return this;
+  }
+
+  public ResourceEvent<T> resourceName(String resourceName) {
+    this.resourceName = resourceName;
+    return this;
+  }
+
+  public ResourceEvent<T> newValue(T newValue) {
+    this.newValue = newValue;
+    return this;
+  }
+
+  public ResourceEvent<T> oldValue(T oldValue) {
+    this.oldValue = oldValue;
+    return this;
+  }
 }

--- a/folio-integration-kafka/folio-kafka-consumer/src/test/java/org/folio/integration/kafka/consumer/filter/EnabledTenantMessageFilterTest.java
+++ b/folio-integration-kafka/folio-kafka-consumer/src/test/java/org/folio/integration/kafka/consumer/filter/EnabledTenantMessageFilterTest.java
@@ -181,7 +181,8 @@ class EnabledTenantMessageFilterTest {
   }
 
   private static ConsumerRecord<String, ResourceEvent<Object>> consumerRecord(String key, String tenant) {
-    var event = new ResourceEvent<>().tenant(tenant);
+    var event = new ResourceEvent<>();
+    event.setTenant(tenant);
     return new ConsumerRecord<>("test-topic", 0, 0L, key, event);
   }
 }

--- a/folio-integration-kafka/folio-kafka-consumer/src/test/java/org/folio/integration/kafka/consumer/filter/EnabledTenantMessageFilterTest.java
+++ b/folio-integration-kafka/folio-kafka-consumer/src/test/java/org/folio/integration/kafka/consumer/filter/EnabledTenantMessageFilterTest.java
@@ -181,7 +181,7 @@ class EnabledTenantMessageFilterTest {
   }
 
   private static ConsumerRecord<String, ResourceEvent<Object>> consumerRecord(String key, String tenant) {
-    var event = ResourceEvent.builder().tenant(tenant).build();
+    var event = new ResourceEvent<>().tenant(tenant);
     return new ConsumerRecord<>("test-topic", 0, 0L, key, event);
   }
 }

--- a/folio-integration-kafka/folio-kafka-consumer/src/test/java/org/folio/integration/kafka/consumer/it/KafkaConsumerFilteringIT.java
+++ b/folio-integration-kafka/folio-kafka-consumer/src/test/java/org/folio/integration/kafka/consumer/it/KafkaConsumerFilteringIT.java
@@ -69,7 +69,6 @@ class KafkaConsumerFilteringIT {
 
   @Autowired private KafkaTemplate<String, String> kafkaTemplate;
   @Autowired private TestEventCollector eventCollector;
-  private ConcurrentKafkaListenerContainerFactory<String, ResourceEvent<Object>> resourceEventContainerFactory;
 
   @BeforeEach
   void setUp() {

--- a/folio-integration-kafka/folio-kafka-consumer/src/test/java/org/folio/integration/kafka/consumer/it/KafkaConsumerFilteringIT.java
+++ b/folio-integration-kafka/folio-kafka-consumer/src/test/java/org/folio/integration/kafka/consumer/it/KafkaConsumerFilteringIT.java
@@ -77,7 +77,7 @@ class KafkaConsumerFilteringIT {
 
   @Test
   void filter_positive_entitledTenant_messageAccepted() throws Exception {
-    kafkaTemplate.send(TOPIC, asJsonString(ResourceEvent.builder().tenant(ENTITLED_TENANT).build())).get();
+    kafkaTemplate.send(TOPIC, asJsonString(new ResourceEvent<>().tenant(ENTITLED_TENANT))).get();
 
     var events = eventCollector.getEvents();
     await().atMost(10, SECONDS).untilAsserted(() ->
@@ -88,8 +88,8 @@ class KafkaConsumerFilteringIT {
 
   @Test
   void filter_positive_nonEntitledTenant_messageFiltered() throws Exception {
-    kafkaTemplate.send(TOPIC, asJsonString(ResourceEvent.builder().tenant(NON_ENTITLED_TENANT).build())).get();
-    kafkaTemplate.send(TOPIC, asJsonString(ResourceEvent.builder().tenant(ENTITLED_TENANT).build())).get();
+    kafkaTemplate.send(TOPIC, asJsonString(new ResourceEvent<>().tenant(NON_ENTITLED_TENANT))).get();
+    kafkaTemplate.send(TOPIC, asJsonString(new ResourceEvent<>().tenant(ENTITLED_TENANT))).get();
 
     var events = eventCollector.getEvents();
     await().atMost(10, SECONDS).untilAsserted(() ->

--- a/folio-integration-kafka/folio-kafka-consumer/src/test/java/org/folio/integration/kafka/consumer/it/KafkaConsumerFilteringIT.java
+++ b/folio-integration-kafka/folio-kafka-consumer/src/test/java/org/folio/integration/kafka/consumer/it/KafkaConsumerFilteringIT.java
@@ -69,6 +69,7 @@ class KafkaConsumerFilteringIT {
 
   @Autowired private KafkaTemplate<String, String> kafkaTemplate;
   @Autowired private TestEventCollector eventCollector;
+  private ConcurrentKafkaListenerContainerFactory<String, ResourceEvent<Object>> resourceEventContainerFactory;
 
   @BeforeEach
   void setUp() {
@@ -77,7 +78,7 @@ class KafkaConsumerFilteringIT {
 
   @Test
   void filter_positive_entitledTenant_messageAccepted() throws Exception {
-    kafkaTemplate.send(TOPIC, asJsonString(new ResourceEvent<>().tenant(ENTITLED_TENANT))).get();
+    kafkaTemplate.send(TOPIC, asJsonString(resourceEvent(ENTITLED_TENANT))).get();
 
     var events = eventCollector.getEvents();
     await().atMost(10, SECONDS).untilAsserted(() ->
@@ -88,14 +89,20 @@ class KafkaConsumerFilteringIT {
 
   @Test
   void filter_positive_nonEntitledTenant_messageFiltered() throws Exception {
-    kafkaTemplate.send(TOPIC, asJsonString(new ResourceEvent<>().tenant(NON_ENTITLED_TENANT))).get();
-    kafkaTemplate.send(TOPIC, asJsonString(new ResourceEvent<>().tenant(ENTITLED_TENANT))).get();
+    kafkaTemplate.send(TOPIC, asJsonString(resourceEvent(NON_ENTITLED_TENANT))).get();
+    kafkaTemplate.send(TOPIC, asJsonString(resourceEvent(ENTITLED_TENANT))).get();
 
     var events = eventCollector.getEvents();
     await().atMost(10, SECONDS).untilAsserted(() ->
       assertThat(events).hasSize(1)
     );
     assertThat(events.getFirst().value().getTenant()).isEqualTo(ENTITLED_TENANT);
+  }
+
+  private static Object resourceEvent(String tenant) {
+    var event = new ResourceEvent<>();
+    event.setTenant(tenant);
+    return event;
   }
 
   @org.springframework.kafka.annotation.EnableKafka


### PR DESCRIPTION
## Purpose

Extends `ResourceEvent<T>` so it supports both Jackson deserialization and programmatic construction via a Lombok builder, which is a prerequisite for the Kafka consumer changes in `mod-users-keycloak`. This PR does not implement the full user story — the core logic lives in the companion module.

US: [MODUSERSKC-154](https://folio-org.atlassian.net/browse/MODUSERSKC-154)

## Approach

### Summary

`ResourceEvent<T>` previously used only `@Builder`, which does not support Jackson deserialization without `@Jacksonized` or an explicit `@JsonDeserialize` configuration. Adding `@NoArgsConstructor` and `@AllArgsConstructor` enables the standard Jackson no-args constructor + setter flow, while renaming the builder entry point to `baseBuilder()` avoids collision with builder methods in subclasses or extension types in consuming modules.

### Implementation Details

- Added `@NoArgsConstructor` and `@AllArgsConstructor` to `ResourceEvent<T>` and renamed the Lombok builder to `@Builder(builderMethodName = "baseBuilder")` to enable Jackson deserialization without removing the builder API.

## Pre-Review Checklist

- [ ] Self-reviewed the diff
- [ ] `NEWS.md` updated with change notes
- [ ] Changes tested locally
- [ ] Dependent module (`mod-users-keycloak`) verified against the updated API
- [ ] **Breaking change**: callers using `ResourceEvent.builder()` must migrate to
      `ResourceEvent.baseBuilder()` after upgrading
- [ ] No new configuration properties introduced
- [ ] Local environment can be recreated cleanly from scratch
- [ ] PR is scoped to a single logical change
