### PR TITLE
KEYCLOAK-112: Upgrade Keycloak testcontainers to 26.6.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-## Version `v3.1.0` (in progress)
+## Version `4.1.0` (In Progress)
+### Changes:
+* Upgrade Keycloak testcontainers to 26.6.2, keycloak-admin-client to 26.0.9 (KEYCLOAK-112)
+
+## Version `v4.0.0` (14.04.2026)
 ### Changes:
 * Support find topics by name in KafkaAdminService (MGRENTITLE-135)
 * Validate semver when getting name or version from artifact id (MGRENTITLE-113)

--- a/folio-backend-testing/README.md
+++ b/folio-backend-testing/README.md
@@ -25,19 +25,19 @@ All Testcontainers images can be overridden via environment variables. This is t
 point tests at images from a private Docker registry or to use a newer image version without
 changing source code.
 
-| Environment variable                | Default image                           | Container  |
-|:------------------------------------|:----------------------------------------|------------|
-| `TESTCONTAINERS_POSTGRES_IMAGE`     | `postgres:16-alpine`                    | PostgreSQL |
-| `TESTCONTAINERS_KAFKA_IMAGE`        | `apache/kafka-native:3.8.0`             | Kafka      |
-| `TESTCONTAINERS_KEYCLOAK_IMAGE`     | `quay.io/keycloak/keycloak:26.5.7`      | Keycloak   |
-| `TESTCONTAINERS_WIREMOCK_IMAGE`     | `wiremock/3.13.2-2-alpine`              | WireMock   |
+| Environment variable                | Default image                      | Container  |
+|:------------------------------------|:-----------------------------------|------------|
+| `TESTCONTAINERS_POSTGRES_IMAGE`     | `postgres:16-alpine`               | PostgreSQL |
+| `TESTCONTAINERS_KAFKA_IMAGE`        | `apache/kafka-native:3.8.0`        | Kafka      |
+| `TESTCONTAINERS_KEYCLOAK_IMAGE`     | `quay.io/keycloak/keycloak:26.6.2` | Keycloak   |
+| `TESTCONTAINERS_WIREMOCK_IMAGE`     | `wiremock/3.13.2-2-alpine`         | WireMock   |
 
 Example — redirect all containers to a private registry:
 
 ```shell
 export TESTCONTAINERS_POSTGRES_IMAGE=registry.example.com/postgres:16-alpine
 export TESTCONTAINERS_KAFKA_IMAGE=registry.example.com/apache/kafka-native:3.8.0
-export TESTCONTAINERS_KEYCLOAK_IMAGE=registry.example.com/keycloak/keycloak:26.5.7
+export TESTCONTAINERS_KEYCLOAK_IMAGE=registry.example.com/keycloak/keycloak:26.6.2
 export TESTCONTAINERS_WIREMOCK_IMAGE=registry.example.com/wiremock:3.13.2-2-alpine
 ```
 

--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/DockerImageRegistry.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/DockerImageRegistry.java
@@ -12,7 +12,7 @@ public class DockerImageRegistry {
 
   public static final String POSTGRES_DEFAULT_IMAGE = "postgres:16-alpine";
   public static final String WIREMOCK_DEFAULT_IMAGE = "wiremock/wiremock:3.13.2-2";
-  public static final String KEYCLOAK_DEFAULT_IMAGE = "quay.io/keycloak/keycloak:26.5.7";
+  public static final String KEYCLOAK_DEFAULT_IMAGE = "quay.io/keycloak/keycloak:26.6.2";
   public static final String KAFKA_DEFAULT_IMAGE    = "apache/kafka-native:3.8.0";
 
   public static String getPostgresImageName() {

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <spring-boot.version>4.0.6</spring-boot.version>
     <apache-commons-collections4.version>4.5.0</apache-commons-collections4.version>
     <apache-commons-lang3.version>3.20.0</apache-commons-lang3.version>
-    <keycloak-admin-client.version>26.0.8</keycloak-admin-client.version>
+    <keycloak-admin-client.version>26.0.9</keycloak-admin-client.version>
 
     <!-- Test dependencies versions -->
     <mockito.version>5.23.0</mockito.version>


### PR DESCRIPTION
### **Purpose**
Fix for [KEYCLOAK-112](https://folio-org.atlassian.net/browse/KEYCLOAK-112)

### **Approach**
Update KEYCLOAK_DEFAULT_IMAGE to 26.6.2 in `DockerImageRegistry`
Update TESTCONTAINERS_KEYCLOAK_IMAGE to 26.6.2 
Update keycloak-admin-client.version to 26.0.9 - the latest version as of today.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [x] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
  > "Verify Dependent Modules" failed for `mod-login-keycloak`. This failure be fixed after merging [this PR](https://github.com/folio-org/mod-login-keycloak/pull/198)
- [x] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
   > This change breaks mod-login-keycloak. [Here is the PR](https://github.com/folio-org/mod-login-keycloak/pull/198) to fix the compatibility issue.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
