### PR TITLE
APPPOCTOOL-90: Upgrade dependencies for Kafka 4.2 compatibility in applications-poc-tools

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
-## Version `v3.1.0` (in progress)
+## Version `v4.1.0` (in progress)
+### Changes:
+* Upgrade dependencies for Kafka 4.2 compatibility in applications-poc-tools (APPPOCTOOL-90)
+
+-------
+
+## Version `v4.0.0` (14.04.2026)
 ### Changes:
 * Support find topics by name in KafkaAdminService (MGRENTITLE-135)
 * Validate semver when getting name or version from artifact id (MGRENTITLE-113)
@@ -22,6 +28,3 @@
 * Bump Spring Boot from 4.0.3 to 4.0.4 fixing Jackson vulns (APPPOCTOOL-83)
 * Upgrade Keycloak testcontainers to 26.5.7 (KEYCLOAK-102)
 * Support tenant-aware Kafka message filtering (APPPOCTOOL-85)
-
-### Migration:
-* Replace KeycloakSecretUtils with SecureStoreKeyProvider, add `application.secret-store.environment=${SECURE_STORE_ENV:folio}` to application.yaml (for Ramsons and Sunflower: add `application.secret-store.environment=${SECURE_STORE_ENV:${ENV:folio}}` to application.yaml).

--- a/folio-backend-testing/README.md
+++ b/folio-backend-testing/README.md
@@ -28,7 +28,7 @@ changing source code.
 | Environment variable                | Default image                           | Container  |
 |:------------------------------------|:----------------------------------------|------------|
 | `TESTCONTAINERS_POSTGRES_IMAGE`     | `postgres:16-alpine`                    | PostgreSQL |
-| `TESTCONTAINERS_KAFKA_IMAGE`        | `apache/kafka-native:3.8.0`             | Kafka      |
+| `TESTCONTAINERS_KAFKA_IMAGE`        | `apache/kafka-native:4.2.0`             | Kafka      |
 | `TESTCONTAINERS_KEYCLOAK_IMAGE`     | `quay.io/keycloak/keycloak:26.5.7`      | Keycloak   |
 | `TESTCONTAINERS_WIREMOCK_IMAGE`     | `wiremock/3.13.2-2-alpine`              | WireMock   |
 
@@ -36,7 +36,7 @@ Example — redirect all containers to a private registry:
 
 ```shell
 export TESTCONTAINERS_POSTGRES_IMAGE=registry.example.com/postgres:16-alpine
-export TESTCONTAINERS_KAFKA_IMAGE=registry.example.com/apache/kafka-native:3.8.0
+export TESTCONTAINERS_KAFKA_IMAGE=registry.example.com/apache/kafka-native:4.2.0
 export TESTCONTAINERS_KEYCLOAK_IMAGE=registry.example.com/keycloak/keycloak:26.5.7
 export TESTCONTAINERS_WIREMOCK_IMAGE=registry.example.com/wiremock:3.13.2-2-alpine
 ```

--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/DockerImageRegistry.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/DockerImageRegistry.java
@@ -13,7 +13,7 @@ public class DockerImageRegistry {
   public static final String POSTGRES_DEFAULT_IMAGE = "postgres:16-alpine";
   public static final String WIREMOCK_DEFAULT_IMAGE = "wiremock/wiremock:3.13.2-2";
   public static final String KEYCLOAK_DEFAULT_IMAGE = "quay.io/keycloak/keycloak:26.5.7";
-  public static final String KAFKA_DEFAULT_IMAGE    = "apache/kafka-native:3.8.0";
+  public static final String KAFKA_DEFAULT_IMAGE    = "apache/kafka-native:4.2.0";
 
   public static String getPostgresImageName() {
     return getImageName(POSTGRES_IMAGE_ENV, POSTGRES_DEFAULT_IMAGE);

--- a/folio-integration-kafka/folio-kafka-common/src/main/java/org/folio/integration/kafka/model/ResourceEvent.java
+++ b/folio-integration-kafka/folio-kafka-common/src/main/java/org/folio/integration/kafka/model/ResourceEvent.java
@@ -1,6 +1,8 @@
 package org.folio.integration.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -31,11 +33,13 @@ public class ResourceEvent<T> implements TenantAwareEvent {
   /**
    * Event type.
    */
+  @NotNull
   private ResourceEventType type;
 
   /**
    * Tenant identifier (name).
    */
+  @NotBlank
   private String tenant;
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <apache-commons-collections4.version>4.5.0</apache-commons-collections4.version>
     <apache-commons-lang3.version>3.20.0</apache-commons-lang3.version>
     <keycloak-admin-client.version>26.0.8</keycloak-admin-client.version>
+    <kafka.version>4.2.0</kafka.version> <!-- can be removed once Spring Boot migrates to this version -->
 
     <!-- Test dependencies versions -->
     <mockito.version>5.23.0</mockito.version>


### PR DESCRIPTION
### **Purpose**
Upgrades the project's Kafka dependency and default test-container image to version 4.2.0 to maintain compatibility with the latest Kafka release ahead of Spring Boot's own migration.
US: [APPPOCTOOL-90](https://folio-org.atlassian.net/browse/APPPOCTOOL-90)

### **Approach**
A `kafka.version` property override is introduced in the root `pom.xml` to pin Kafka to 4.2.0 before Spring Boot officially adopts this version. The default Kafka test-container image in `DockerImageRegistry` is updated in parallel to keep integration tests consistent with the upgraded runtime dependency.

**Implementation details:**

- Added `kafka.version` property (`4.2.0`) to root `pom.xml` to override Spring Boot's managed Kafka version; a comment marks the property for removal once Spring Boot migrates to this version natively.
- Updated `KAFKA_DEFAULT_IMAGE` constant in `DockerImageRegistry` from `apache/kafka-native:3.8.0` to `apache/kafka-native:4.2.0`, aligning the default test-container image with the upgraded dependency.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.