### PR TITLE
KEYCLOAK-116: Upgrade Keycloak testcontainers to 26.6.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 ### Changes:
 * Upgrade Keycloak testcontainers to 26.6.2, keycloak-admin-client to 26.0.9 (KEYCLOAK-112)
 * Upgrade dependencies for Kafka 4.2 compatibility in applications-poc-tools (APPPOCTOOL-90)
+* Upgrade Keycloak testcontainers to 26.6.3 (KEYCLOAK-116)
 
 -------
 

--- a/folio-backend-testing/README.md
+++ b/folio-backend-testing/README.md
@@ -29,7 +29,7 @@ changing source code.
 |:------------------------------------|:-----------------------------------|------------|
 | `TESTCONTAINERS_POSTGRES_IMAGE`     | `postgres:16-alpine`               | PostgreSQL |
 | `TESTCONTAINERS_KAFKA_IMAGE`        | `apache/kafka-native:4.2.0`        | Kafka      |
-| `TESTCONTAINERS_KEYCLOAK_IMAGE`     | `quay.io/keycloak/keycloak:26.6.2` | Keycloak   |
+| `TESTCONTAINERS_KEYCLOAK_IMAGE`     | `quay.io/keycloak/keycloak:26.6.3` | Keycloak   |
 | `TESTCONTAINERS_WIREMOCK_IMAGE`     | `wiremock/3.13.2-2-alpine`         | WireMock   |
 
 Example — redirect all containers to a private registry:
@@ -37,7 +37,7 @@ Example — redirect all containers to a private registry:
 ```shell
 export TESTCONTAINERS_POSTGRES_IMAGE=registry.example.com/postgres:16-alpine
 export TESTCONTAINERS_KAFKA_IMAGE=registry.example.com/apache/kafka-native:4.2.0
-export TESTCONTAINERS_KEYCLOAK_IMAGE=registry.example.com/keycloak/keycloak:26.6.2
+export TESTCONTAINERS_KEYCLOAK_IMAGE=registry.example.com/keycloak/keycloak:26.6.3
 export TESTCONTAINERS_WIREMOCK_IMAGE=registry.example.com/wiremock:3.13.2-2-alpine
 ```
 

--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/DockerImageRegistry.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/DockerImageRegistry.java
@@ -12,7 +12,7 @@ public class DockerImageRegistry {
 
   public static final String POSTGRES_DEFAULT_IMAGE = "postgres:16-alpine";
   public static final String WIREMOCK_DEFAULT_IMAGE = "wiremock/wiremock:3.13.2-2";
-  public static final String KEYCLOAK_DEFAULT_IMAGE = "quay.io/keycloak/keycloak:26.6.2";
+  public static final String KEYCLOAK_DEFAULT_IMAGE = "quay.io/keycloak/keycloak:26.6.3";
   public static final String KAFKA_DEFAULT_IMAGE    = "apache/kafka-native:4.2.0";
 
   public static String getPostgresImageName() {


### PR DESCRIPTION
### **Purpose**
Fix for [KEYCLOAK-116](https://folio-org.atlassian.net/browse/KEYCLOAK-116)

Approach
Update KEYCLOAK_DEFAULT_IMAGE to 26.6.3 in DockerImageRegistry
Update TESTCONTAINERS_KEYCLOAK_IMAGE to 26.6.3

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [x] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
