### PR TITLE
APPPOCTOOL-37: Register Kong container image in DockerImageRegistry

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Upgrade dependencies for Kafka 4.2 compatibility in applications-poc-tools (APPPOCTOOL-90)
 * Upgrade Keycloak testcontainers to 26.6.3 (KEYCLOAK-116)
 * Replace upstream Keycloak container with folio-keycloak in integration tests (APPPOCTOOL-37)
+* Register Kong container image in DockerImageRegistry (APPPOCTOOL-37)
 
 -------
 

--- a/folio-backend-testing/README.md
+++ b/folio-backend-testing/README.md
@@ -15,6 +15,7 @@ infrastructure without additional scope configuration.
 - [Base Test Class](#base-test-class)
 - [WireMock Integration](#wiremock-integration)
 - [Keycloak Integration](#keycloak-integration)
+- [Kong Integration](#kong-integration)
 - [Kafka Integration](#kafka-integration)
 
 ---
@@ -33,6 +34,8 @@ changing source code.
 | `TESTCONTAINERS_WIREMOCK_IMAGE`             | `wiremock/3.13.2-2-alpine`         | WireMock image                           |
 | `TESTCONTAINERS_KEYCLOAK_LOG_LEVEL`         | `INFO`                             | Keycloak container log level             |
 | `TESTCONTAINERS_KEYCLOAK_READINESS_TIMEOUT` | `60`                               | Seconds to wait for Keycloak custom-init |
+| `TESTCONTAINERS_KONG_IMAGE`                 | `folioci/folio-kong:latest`        | Kong image                               |
+| `TESTCONTAINERS_KONG_READINESS_TIMEOUT`     | `120`                              | Seconds to wait for Kong startup         |
 
 Example — redirect all containers to a private registry:
 
@@ -41,6 +44,7 @@ export TESTCONTAINERS_POSTGRES_IMAGE=registry.example.com/postgres:16-alpine
 export TESTCONTAINERS_KAFKA_IMAGE=registry.example.com/apache/kafka-native:4.2.0
 export TESTCONTAINERS_KEYCLOAK_IMAGE=registry.example.com/folioci/folio-keycloak:latest
 export TESTCONTAINERS_WIREMOCK_IMAGE=registry.example.com/wiremock:3.13.2-2-alpine
+export TESTCONTAINERS_KONG_IMAGE=registry.example.com/folioci/folio-kong:latest
 ```
 
 Image resolution is handled by `DockerImageRegistry`. Each `getXxxImageName()` method reads the
@@ -310,6 +314,23 @@ The Keycloak admin client is accessible statically for advanced scenarios:
 ```java
 Keycloak adminClient = KeycloakContainerExtension.getKeycloakAdminClient();
 ```
+
+---
+
+## Kong Integration
+
+The `folioci/folio-kong` image runs DB migrations, sets `KONG_ROUTER_FLAVOR=expressions`,
+installs the `auth-headers-manager` plugin, and applies a `deck sync` pass that loads the CORS
+policy and global plugins — all before Kong begins serving traffic. Module `KongGatewayExtension`
+implementations use this image via `DockerImageRegistry.getKongImageName()`.
+
+### Readiness check
+
+Because `deck sync` runs after Kong's HTTP endpoint is already reachable, a plain port-listening
+wait is not sufficient. Module extensions use an HTTP wait strategy that polls `GET /status` on
+port 8001 until it responds with HTTP 200. Tests start only after the full startup sequence —
+migrations and deck sync — is complete. The wait is bounded by
+`TESTCONTAINERS_KONG_READINESS_TIMEOUT` (default 120 s).
 
 ---
 

--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/DockerImageRegistry.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/DockerImageRegistry.java
@@ -7,13 +7,15 @@ public class DockerImageRegistry {
 
   public static final String ENV_POSTGRES_IMAGE = "TESTCONTAINERS_POSTGRES_IMAGE";
   public static final String ENV_WIREMOCK_IMAGE = "TESTCONTAINERS_WIREMOCK_IMAGE";
-  public static final String ENV_KEYCLOAK_IMAGE = "TESTCONTAINERS_KEYCLOAK_IMAGE";
   public static final String ENV_KAFKA_IMAGE    = "TESTCONTAINERS_KAFKA_IMAGE";
+  public static final String ENV_KEYCLOAK_IMAGE = "TESTCONTAINERS_KEYCLOAK_IMAGE";
+  public static final String ENV_KONG_IMAGE     = "TESTCONTAINERS_KONG_IMAGE";
 
   public static final String POSTGRES_DEFAULT_IMAGE = "postgres:16-alpine";
   public static final String WIREMOCK_DEFAULT_IMAGE = "wiremock/wiremock:3.13.2-2";
-  public static final String KEYCLOAK_DEFAULT_IMAGE = "folioci/folio-keycloak:latest";
   public static final String KAFKA_DEFAULT_IMAGE    = "apache/kafka-native:4.2.0";
+  public static final String KEYCLOAK_DEFAULT_IMAGE = "folioci/folio-keycloak:latest";
+  public static final String KONG_DEFAULT_IMAGE     = "folioci/folio-kong:latest";
 
   public static String getPostgresImageName() {
     return getImageName(ENV_POSTGRES_IMAGE, POSTGRES_DEFAULT_IMAGE);
@@ -29,6 +31,10 @@ public class DockerImageRegistry {
 
   public static String getKafkaImageName() {
     return getImageName(ENV_KAFKA_IMAGE, KAFKA_DEFAULT_IMAGE);
+  }
+
+  public static String getKongImageName() {
+    return getImageName(ENV_KONG_IMAGE, KONG_DEFAULT_IMAGE);
   }
 
   private static String getImageName(String imageEnvVar, String defaultImageName) {


### PR DESCRIPTION
### Purpose

Testing infrastructure relies on centrally managed Docker image names so they can be overridden by environment variable without touching module code. Adding a Kong entry to `DockerImageRegistry` completes the pattern already established for Keycloak, Kafka, Postgres, and WireMock.

US: [APPPOCTOOL-37](https://folio-org.atlassian.net/browse/APPPOCTOOL-37)

### Approach

`DockerImageRegistry` already provides env-overridable image name getters for Postgres, WireMock, Kafka, and Keycloak. This change adds the same pattern for Kong so that downstream modules no longer hard-code the image string.

- Added `ENV_KONG_IMAGE` (`TESTCONTAINERS_KONG_IMAGE`) and `KONG_DEFAULT_IMAGE` (`folioci/folio-kong:latest`) constants to `DockerImageRegistry`, following the same naming convention as existing entries.
- Added `getKongImageName()` factory method that resolves the effective image name from the environment variable or falls back to the default.

### Pre-Review Checklist

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [x] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [x] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.