### PR TITLE
APPPOCTOOL-95: Add configurable connect/read timeouts to Keycloak admin client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ temp/
 ### Agents ###
 .claude/
 .codemie/
+CLAUDE.md
+AGENTS.md

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Upgrade Keycloak testcontainers to 26.6.3 (KEYCLOAK-116)
 * Replace upstream Keycloak container with folio-keycloak in integration tests (APPPOCTOOL-37)
 * Register Kong container image in DockerImageRegistry (APPPOCTOOL-37)
+* Add configurable connect/read timeouts for Keycloak admin client (APPPOCTOOL-95)
 
 -------
 

--- a/folio-security/README.md
+++ b/folio-security/README.md
@@ -59,6 +59,8 @@ permits all requests (useful for local development).
 | `application.keycloak.admin.username`                                       | `String`  | Admin username                                           |
 | `application.keycloak.admin.password`                                       | `String`  | Admin password                                           |
 | `application.keycloak.admin.grant-type`                                     | `String`  | Admin grant type                                         |
+| `application.keycloak.admin.connect-timeout`                                | `Duration`| Admin client connect timeout (default: `10s`)            |
+| `application.keycloak.admin.read-timeout`                                   | `Duration`| Admin client read/socket timeout (default: `60s`)        |
 | `application.keycloak.client.client-id`                                     | `String`  | Backend service client ID                                |
 | `application.keycloak.tls.enabled`                                          | `boolean` | Enable TLS for Keycloak HTTP client                      |
 | `application.keycloak.tls.trust-store-path`                                 | `String`  | Truststore file path                                     |
@@ -67,6 +69,10 @@ permits all requests (useful for local development).
 | `application.keycloak.jwt-cache-configuration.validate-uri`                 | `boolean` | Validate token issuer against `keycloak.url`             |
 | `application.keycloak.jwt-cache-configuration.jwks-refresh-interval`        | `int`     | JWKS refresh interval in seconds (default: `60`)         |
 | `application.keycloak.jwt-cache-configuration.forced-jwks-refresh-interval` | `int`     | Forced JWKS refresh interval in seconds (default: `60`)  |
+
+When an admin client call exceeds `connect-timeout` or `read-timeout`, it fails with a `jakarta.ws.rs.ProcessingException`
+(wrapping a `ConnectTimeoutException` / `SocketTimeoutException`), releasing the caller thread so existing retry logic can
+observe it.
 
 ### Okapi properties
 

--- a/folio-security/src/main/java/org/folio/security/integration/keycloak/configuration/properties/KeycloakAdminProperties.java
+++ b/folio-security/src/main/java/org/folio/security/integration/keycloak/configuration/properties/KeycloakAdminProperties.java
@@ -1,5 +1,6 @@
 package org.folio.security.integration.keycloak.configuration.properties;
 
+import java.time.Duration;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
@@ -13,4 +14,19 @@ public class KeycloakAdminProperties {
   private String username;
   private String password;
   private String grantType;
+
+  /**
+   * Connect timeout for the Keycloak admin client HTTP calls.
+   *
+   * <p>Bounds how long a request waits to establish a connection before failing. Defaults to {@code 10s}.</p>
+   */
+  private Duration connectTimeout = Duration.ofSeconds(10);
+
+  /**
+   * Read/socket timeout for the Keycloak admin client HTTP calls.
+   *
+   * <p>Bounds how long a request waits for a response after the connection is established before failing.
+   * Defaults to {@code 60s}.</p>
+   */
+  private Duration readTimeout = Duration.ofSeconds(60);
 }

--- a/folio-security/src/main/java/org/folio/security/integration/keycloak/utils/ClientBuildUtils.java
+++ b/folio-security/src/main/java/org/folio/security/integration/keycloak/utils/ClientBuildUtils.java
@@ -1,16 +1,19 @@
 package org.folio.security.integration.keycloak.utils;
 
 import static jakarta.ws.rs.client.ClientBuilder.newBuilder;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.stripToNull;
 import static org.folio.common.utils.tls.Utils.IS_HOSTNAME_VERIFICATION_DISABLED;
 import static org.folio.common.utils.tls.Utils.buildSslContext;
 
+import jakarta.ws.rs.client.ClientBuilder;
+import java.time.Duration;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.folio.common.configuration.properties.TlsProperties;
+import org.folio.security.integration.keycloak.configuration.properties.KeycloakAdminProperties;
 import org.folio.security.integration.keycloak.configuration.properties.KeycloakProperties;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.keycloak.admin.client.JacksonProvider;
@@ -22,32 +25,56 @@ import org.keycloak.admin.client.KeycloakBuilder;
 public class ClientBuildUtils {
 
   private static final DefaultHostnameVerifier DEFAULT_HOSTNAME_VERIFIER = new DefaultHostnameVerifier();
+  private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(60);
 
   public static Keycloak buildKeycloakAdminClient(String clientSecret, KeycloakProperties properties) {
     var admin = properties.getAdmin();
-    var builder = KeycloakBuilder.builder()
+    return KeycloakBuilder.builder()
       .realm("master")
       .serverUrl(properties.getUrl())
       .clientId(admin.getClientId())
       .clientSecret(stripToNull(clientSecret))
       .username(stripToNull(admin.getUsername()))
       .password(stripToNull(admin.getPassword()))
-      .grantType(admin.getGrantType());
-
-    if (properties.getTls() != null && properties.getTls().isEnabled()) {
-      builder.resteasyClient(buildResteasyClient(properties.getTls()));
-    }
-    return builder.build();
+      .grantType(admin.getGrantType())
+      .resteasyClient(buildResteasyClient(properties))
+      .build();
   }
 
-  private static ResteasyClient buildResteasyClient(TlsProperties tls) {
+  static ResteasyClient buildResteasyClient(KeycloakProperties properties) {
+    return (ResteasyClient) configureClientBuilder(properties).build();
+  }
+
+  static ClientBuilder configureClientBuilder(KeycloakProperties properties) {
+    var admin = properties.getAdmin();
     var clientBuilder = newBuilder()
-      .hostnameVerifier(IS_HOSTNAME_VERIFICATION_DISABLED ? NoopHostnameVerifier.INSTANCE : DEFAULT_HOSTNAME_VERIFIER)
+      .connectTimeout(resolveConnectTimeout(admin).toMillis(), MILLISECONDS)
+      .readTimeout(resolveReadTimeout(admin).toMillis(), MILLISECONDS)
       .register(JacksonProvider.class);
-    if (isBlank(tls.getTrustStorePath())) {
-      log.debug("Creating ResteasyClient for Public Trusted Certificates");
-      return (ResteasyClient) clientBuilder.build();
+
+    var tls = properties.getTls();
+    if (tls != null && tls.isEnabled()) {
+      clientBuilder.hostnameVerifier(
+        IS_HOSTNAME_VERIFICATION_DISABLED ? NoopHostnameVerifier.INSTANCE : DEFAULT_HOSTNAME_VERIFIER);
+      if (isBlank(tls.getTrustStorePath())) {
+        log.debug("Creating ResteasyClient for Public Trusted Certificates");
+      } else {
+        clientBuilder.sslContext(buildSslContext(tls));
+      }
     }
-    return (ResteasyClient) clientBuilder.sslContext(buildSslContext(tls)).build();
+    return clientBuilder;
+  }
+
+  private static Duration resolveConnectTimeout(KeycloakAdminProperties admin) {
+    return admin != null && admin.getConnectTimeout() != null
+      ? admin.getConnectTimeout()
+      : DEFAULT_CONNECT_TIMEOUT;
+  }
+
+  private static Duration resolveReadTimeout(KeycloakAdminProperties admin) {
+    return admin != null && admin.getReadTimeout() != null
+      ? admin.getReadTimeout()
+      : DEFAULT_READ_TIMEOUT;
   }
 }

--- a/folio-security/src/test/java/org/folio/security/integration/keycloak/utils/ClientBuildUtilsTest.java
+++ b/folio-security/src/test/java/org/folio/security/integration/keycloak/utils/ClientBuildUtilsTest.java
@@ -1,17 +1,41 @@
 package org.folio.security.integration.keycloak.utils;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.security.integration.keycloak.utils.ClientBuildUtils.buildKeycloakAdminClient;
+import static org.folio.security.integration.keycloak.utils.ClientBuildUtils.configureClientBuilder;
 
+import java.time.Duration;
 import org.folio.common.configuration.properties.TlsProperties;
 import org.folio.security.integration.keycloak.configuration.properties.KeycloakAdminProperties;
 import org.folio.security.integration.keycloak.configuration.properties.KeycloakClientProperties;
 import org.folio.security.integration.keycloak.configuration.properties.KeycloakProperties;
 import org.folio.test.types.UnitTest;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.junit.jupiter.api.Test;
 
 @UnitTest
 class ClientBuildUtilsTest {
+
+  @Test
+  void configureClientBuilder_positive_defaultTimeouts() {
+    var keycloakProperties = keycloakProperties(false);
+    var clientBuilder = (ResteasyClientBuilder) configureClientBuilder(keycloakProperties);
+
+    assertThat(clientBuilder.getConnectionTimeout(MILLISECONDS)).isEqualTo(10_000L);
+    assertThat(clientBuilder.getReadTimeout(MILLISECONDS)).isEqualTo(60_000L);
+  }
+
+  @Test
+  void configureClientBuilder_positive_customTimeouts() {
+    var keycloakProperties = keycloakProperties(true);
+    keycloakProperties.getAdmin().setConnectTimeout(Duration.ofSeconds(3));
+    keycloakProperties.getAdmin().setReadTimeout(Duration.ofSeconds(15));
+    var clientBuilder = (ResteasyClientBuilder) configureClientBuilder(keycloakProperties);
+
+    assertThat(clientBuilder.getConnectionTimeout(MILLISECONDS)).isEqualTo(3_000L);
+    assertThat(clientBuilder.getReadTimeout(MILLISECONDS)).isEqualTo(15_000L);
+  }
 
   @Test
   void buildKeycloakAdminClient_positive_tlsDisabled() {


### PR DESCRIPTION
### **Purpose**
Keycloak admin client calls previously ran with no connect or read timeouts, so a blocked or unresponsive Keycloak endpoint could leave caller threads waiting indefinitely. This adds explicit, configurable timeouts with safe defaults to bound those calls and keep callers responsive. Related issue: https://folio-org.atlassian.net/browse/APPPOCTOOL-95

### **Approach**
- Added `connectTimeout` (default `10s`) and `readTimeout` (default `60s`) as `Duration` properties on `KeycloakAdminProperties`, overridable via `application.keycloak.admin.connect-timeout` / `read-timeout`.
- Reworked `ClientBuildUtils` to always build a custom RESTEasy client (not only on the TLS path) so timeouts apply on every path; TLS hostname verifier and SSL context remain gated behind `tls.enabled`.
- Applied the timeouts to the underlying HTTP client with null-safe fallback to the defaults; timeout failures surface as `ProcessingException` for existing caller retry logic.
- Documented the new properties in `folio-security/README.md`, added a `NEWS.md` entry, and extended `ClientBuildUtilsTest` to assert default and custom timeout values.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [x] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.