### PR TITLE
KEYCLOAK-124: update Keycloak admin client to 26.0.11

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # applications-poc-tools
 
-Multi-module Maven library of shared classes for FOLIO backend development and testing. Spring Boot 4.0.2, Java 21, Log4j2.
+Multi-module Maven library of shared classes for FOLIO backend development and testing. Spring Boot 4.x, Java 21, Log4j2.
 
 ## Build & Test
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 * Replace upstream Keycloak container with folio-keycloak in integration tests (APPPOCTOOL-37)
 * Register Kong container image in DockerImageRegistry (APPPOCTOOL-37)
 * Add configurable connect/read timeouts for Keycloak admin client (APPPOCTOOL-95)
-
+* Update keycloak admin client to 26.0.11 (KEYCLOAK-124)
 -------
 
 ## Version `v4.0.0` (14.04.2026)

--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/DockerImageRegistry.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/DockerImageRegistry.java
@@ -14,7 +14,7 @@ public class DockerImageRegistry {
   public static final String POSTGRES_DEFAULT_IMAGE = "postgres:16-alpine";
   public static final String WIREMOCK_DEFAULT_IMAGE = "wiremock/wiremock:3.13.2-2";
   public static final String KAFKA_DEFAULT_IMAGE    = "apache/kafka-native:4.2.0";
-  public static final String KEYCLOAK_DEFAULT_IMAGE = "keycloak/keycloak:26.7.0";
+  public static final String KEYCLOAK_DEFAULT_IMAGE = "yauhenvavilkinebsco/folio-keycloak:1";
   public static final String KONG_DEFAULT_IMAGE     = "folioci/folio-kong:latest";
 
   public static String getPostgresImageName() {

--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/DockerImageRegistry.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/DockerImageRegistry.java
@@ -14,7 +14,7 @@ public class DockerImageRegistry {
   public static final String POSTGRES_DEFAULT_IMAGE = "postgres:16-alpine";
   public static final String WIREMOCK_DEFAULT_IMAGE = "wiremock/wiremock:3.13.2-2";
   public static final String KAFKA_DEFAULT_IMAGE    = "apache/kafka-native:4.2.0";
-  public static final String KEYCLOAK_DEFAULT_IMAGE = "yauhenvavilkinebsco/folio-keycloak:1";
+  public static final String KEYCLOAK_DEFAULT_IMAGE = "yauhenvavilkinebsco/folio-keycloak:2";
   public static final String KONG_DEFAULT_IMAGE     = "folioci/folio-kong:latest";
 
   public static String getPostgresImageName() {

--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/DockerImageRegistry.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/DockerImageRegistry.java
@@ -14,7 +14,7 @@ public class DockerImageRegistry {
   public static final String POSTGRES_DEFAULT_IMAGE = "postgres:16-alpine";
   public static final String WIREMOCK_DEFAULT_IMAGE = "wiremock/wiremock:3.13.2-2";
   public static final String KAFKA_DEFAULT_IMAGE    = "apache/kafka-native:4.2.0";
-  public static final String KEYCLOAK_DEFAULT_IMAGE = "folioci/folio-keycloak:latest";
+  public static final String KEYCLOAK_DEFAULT_IMAGE = "keycloak/keycloak:26.7.0";
   public static final String KONG_DEFAULT_IMAGE     = "folioci/folio-kong:latest";
 
   public static String getPostgresImageName() {

--- a/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/DockerImageRegistry.java
+++ b/folio-backend-testing/src/main/java/org/folio/test/extensions/impl/DockerImageRegistry.java
@@ -14,7 +14,7 @@ public class DockerImageRegistry {
   public static final String POSTGRES_DEFAULT_IMAGE = "postgres:16-alpine";
   public static final String WIREMOCK_DEFAULT_IMAGE = "wiremock/wiremock:3.13.2-2";
   public static final String KAFKA_DEFAULT_IMAGE    = "apache/kafka-native:4.2.0";
-  public static final String KEYCLOAK_DEFAULT_IMAGE = "yauhenvavilkinebsco/folio-keycloak:2";
+  public static final String KEYCLOAK_DEFAULT_IMAGE = "folioci/folio-keycloak:latest";
   public static final String KONG_DEFAULT_IMAGE     = "folioci/folio-kong:latest";
 
   public static String getPostgresImageName() {

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <spring-boot.version>4.1.0</spring-boot.version>
     <apache-commons-collections4.version>4.5.0</apache-commons-collections4.version>
     <apache-commons-lang3.version>3.20.0</apache-commons-lang3.version>
-    <keycloak-admin-client.version>26.0.9</keycloak-admin-client.version>
+    <keycloak-admin-client.version>26.0.11</keycloak-admin-client.version>
     <kafka.version>4.2.0</kafka.version> <!-- can be removed once Spring Boot migrates to this version -->
 
     <!-- Test dependencies versions -->


### PR DESCRIPTION
### **Purpose**
Update the Keycloak admin client dependency to `26.0.11` to keep the library aligned with the newer Keycloak stack used in this repository. Add the corresponding release note entry for `KEYCLOAK-124` and refresh the repository guidance text that still described Spring Boot as `4.0.2`. Related issue: https://folio-org.atlassian.net/browse/KEYCLOAK-124

### **Approach**
- bump `keycloak-admin-client.version` in `pom.xml` from `26.0.9` to `26.0.11`
- add the `KEYCLOAK-124` change note to `NEWS.md`
- update `AGENTS.md` to describe the repository as Spring Boot `4.x`

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [x] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.